### PR TITLE
ci: fix the publishing of ts client [skip ci]

### DIFF
--- a/.github/workflows/release-clients.yml
+++ b/.github/workflows/release-clients.yml
@@ -4,12 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       releaseTag:
-        description: "Tag to release clients (e.g. identus-cloud-agent-v1.33.0)"
+        description: "Tag to release clients (e.g. cloud-agent-v1.33.0)"
         required: true
         type: string
   push:
     tags:
-      - "identus-cloud-agent-v*"
+      - "cloud-agent-v*"
 
 permissions:
   contents: read

--- a/.github/workflows/release-clients.yml
+++ b/.github/workflows/release-clients.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   publish-clients:
-    name: 'Build and publish Identus-cloud-Agent clients'
+    name: "Build and publish Identus Cloud Agent clients"
     runs-on: ubuntu-latest
     env:
       VERSION_TAG: ${{inputs.releaseTag || github.ref_name}}
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2.8.0

--- a/.github/workflows/release-clients.yml
+++ b/.github/workflows/release-clients.yml
@@ -11,6 +11,10 @@ on:
     tags:
       - "identus-cloud-agent-v*"
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   publish-clients:
     name: 'Build and publish Identus-cloud-Agent clients'
@@ -19,7 +23,7 @@ jobs:
       VERSION_TAG: ${{inputs.releaseTag || github.ref_name}}
       GITHUB_ACTOR: "hyperledger-bot"
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+      NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Checkout

--- a/cloud-agent/client/generator/publish-clients.sh
+++ b/cloud-agent/client/generator/publish-clients.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-set -e
+#set -e
 
 AGENT_VERSION=${VERSION_TAG:13}
+echo version=${AGENT_VERSION}
 
 # install dependencies
 yarn

--- a/cloud-agent/client/generator/publish-clients.sh
+++ b/cloud-agent/client/generator/publish-clients.sh
@@ -7,7 +7,7 @@ AGENT_VERSION=${VERSION_TAG:13}
 yarn
 
 # kotlin
-gradle -p ../kotlin -Pversion=${AGENT_VERSION} publish
+# gradle -p ../kotlin -Pversion=${AGENT_VERSION} publish
 
 # typescript
 yarn --cwd ../typescript

--- a/cloud-agent/client/generator/publish-clients.sh
+++ b/cloud-agent/client/generator/publish-clients.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#set -e
+set -e
 
 AGENT_VERSION=${VERSION_TAG:13}
 echo version=${AGENT_VERSION}
@@ -8,7 +8,7 @@ echo version=${AGENT_VERSION}
 yarn
 
 # kotlin
-# gradle -p ../kotlin -Pversion=${AGENT_VERSION} publish
+gradle -p ../kotlin -Pversion=${AGENT_VERSION} publish
 
 # typescript
 yarn --cwd ../typescript

--- a/cloud-agent/client/typescript/package.json
+++ b/cloud-agent/client/typescript/package.json
@@ -13,7 +13,7 @@
     "openapi-client",
     "openapi-generator"
   ],
-  "license": "Unlicensed",
+  "license": "Apache-2.0",
   "main": "./dist/index.js",
   "type": "commonjs",
   "exports": {


### PR DESCRIPTION
### Description: 
- changed the tag to dispatch the workflow
- use GITHUB_TOKEN to publish ts package to ghcr.io


### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
