### PR TITLE
chore: update OID4VCI example script to use issuer metadata

### DIFF
--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/CredentialIssuerEndpoints.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/CredentialIssuerEndpoints.scala
@@ -86,12 +86,12 @@ object CredentialIssuerEndpoints {
 
   val createCredentialOfferEndpoint: Endpoint[
     (ApiKeyCredentials, JwtCredentials),
-    (RequestContext, String, CredentialOfferRequest),
+    (RequestContext, UUID, CredentialOfferRequest),
     ErrorResponse,
     CredentialOfferResponse,
     Any
   ] = baseIssuerPrivateEndpoint.post
-    .in(didRefPathSegment / "credential-offers")
+    .in(issuerIdPathSegment / "credential-offers")
     .in(jsonBody[CredentialOfferRequest])
     .out(
       statusCode(StatusCode.Created).description("CredentialOffer created successfully"),

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/CredentialIssuerServerEndpoints.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/CredentialIssuerServerEndpoints.scala
@@ -34,9 +34,9 @@ case class CredentialIssuerServerEndpoints(
     CredentialIssuerEndpoints.createCredentialOfferEndpoint
       .zServerSecurityLogic(SecurityLogic.authorizeWalletAccessWith(_)(authenticator, authorizer))
       .serverLogic { wac =>
-        { case (rc, id, request) =>
+        { case (rc, issuerId, request) =>
           credentialIssuerController
-            .createCredentialOffer(rc, id, request)
+            .createCredentialOffer(rc, issuerId, request)
             .provideSomeLayer(ZLayer.succeed(wac))
             .logTrace(rc)
         }

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/controller/CredentialIssuerController.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/controller/CredentialIssuerController.scala
@@ -28,7 +28,7 @@ trait CredentialIssuerController {
 
   def createCredentialOffer(
       ctx: RequestContext,
-      didRef: String,
+      issuerId: UUID,
       credentialOfferRequest: CredentialOfferRequest
   ): ZIO[WalletAccessContext, ErrorResponse, CredentialOfferResponse]
 
@@ -216,13 +216,12 @@ case class CredentialIssuerControllerImpl(
 
   override def createCredentialOffer(
       ctx: RequestContext,
-      didRef: String,
+      issuerId: UUID,
       credentialOfferRequest: CredentialOfferRequest
   ): ZIO[WalletAccessContext, ErrorResponse, CredentialOfferResponse] = {
     for {
-      canonicalPrismDID <- parseIssuerDIDBasicError(didRef)
       resp <- credentialIssuerService
-        .createCredentialOffer(canonicalPrismDID, credentialOfferRequest.claims)
+        .createCredentialOffer(issuerId, credentialOfferRequest.claims)
         .map(offer => CredentialOfferResponse(offer.offerUri))
         .mapError(ue =>
           internalServerError(detail = Some(s"Unexpected error while creating credential offer: ${ue.message}"))

--- a/examples/.nickel/versions.ncl
+++ b/examples/.nickel/versions.ncl
@@ -1,6 +1,6 @@
 {
   # identus
-  agent = "1.32.0-SNAPSHOT",
+  agent = "1.33.0-SNAPSHOT",
   node = "2.2.1",
   # 3rd party
   caddy = "2.7.6-alpine",

--- a/examples/mt-keycloak-vault/compose.yaml
+++ b/examples/mt-keycloak-vault/compose.yaml
@@ -53,7 +53,7 @@ services:
       SECRET_STORAGE_BACKEND: vault
       VAULT_ADDR: http://vault-default:8200
       VAULT_TOKEN: admin
-    image: ghcr.io/hyperledger/identus-cloud-agent:1.32.0-SNAPSHOT
+    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.0-SNAPSHOT
     restart: always
   caddy-default:
     configs:

--- a/examples/mt-keycloak/compose.yaml
+++ b/examples/mt-keycloak/compose.yaml
@@ -51,7 +51,7 @@ services:
       PRISM_NODE_PORT: '50053'
       REST_SERVICE_URL: http://caddy-default:8080/prism-agent
       SECRET_STORAGE_BACKEND: postgres
-    image: ghcr.io/hyperledger/identus-cloud-agent:1.32.0-SNAPSHOT
+    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.0-SNAPSHOT
     restart: always
   caddy-default:
     configs:

--- a/examples/mt/compose.yaml
+++ b/examples/mt/compose.yaml
@@ -44,7 +44,7 @@ services:
       PRISM_NODE_PORT: '50053'
       REST_SERVICE_URL: http://caddy-default:8080/prism-agent
       SECRET_STORAGE_BACKEND: postgres
-    image: ghcr.io/hyperledger/identus-cloud-agent:1.32.0-SNAPSHOT
+    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.0-SNAPSHOT
     restart: always
   caddy-default:
     configs:

--- a/examples/st-multi/compose.yaml
+++ b/examples/st-multi/compose.yaml
@@ -76,7 +76,7 @@ services:
       PRISM_NODE_PORT: '50053'
       REST_SERVICE_URL: http://caddy-holder:8081/prism-agent
       SECRET_STORAGE_BACKEND: postgres
-    image: ghcr.io/hyperledger/identus-cloud-agent:1.32.0-SNAPSHOT
+    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.0-SNAPSHOT
     restart: always
   agent-issuer:
     depends_on:
@@ -106,7 +106,7 @@ services:
       PRISM_NODE_PORT: '50053'
       REST_SERVICE_URL: http://caddy-issuer:8080/prism-agent
       SECRET_STORAGE_BACKEND: postgres
-    image: ghcr.io/hyperledger/identus-cloud-agent:1.32.0-SNAPSHOT
+    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.0-SNAPSHOT
     restart: always
   agent-verifier:
     depends_on:
@@ -136,7 +136,7 @@ services:
       PRISM_NODE_PORT: '50053'
       REST_SERVICE_URL: http://caddy-verifier:8082/prism-agent
       SECRET_STORAGE_BACKEND: postgres
-    image: ghcr.io/hyperledger/identus-cloud-agent:1.32.0-SNAPSHOT
+    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.0-SNAPSHOT
     restart: always
   caddy-holder:
     configs:

--- a/examples/st-oid4vci/compose.yaml
+++ b/examples/st-oid4vci/compose.yaml
@@ -44,7 +44,7 @@ services:
       PRISM_NODE_PORT: '50053'
       REST_SERVICE_URL: http://caddy-issuer:8080/prism-agent
       SECRET_STORAGE_BACKEND: postgres
-    image: ghcr.io/hyperledger/identus-cloud-agent:1.32.0-SNAPSHOT
+    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.0-SNAPSHOT
     restart: always
   caddy-issuer:
     configs:

--- a/examples/st-vault/compose.yaml
+++ b/examples/st-vault/compose.yaml
@@ -46,7 +46,7 @@ services:
       SECRET_STORAGE_BACKEND: vault
       VAULT_ADDR: http://vault-issuer:8200
       VAULT_TOKEN: admin
-    image: ghcr.io/hyperledger/identus-cloud-agent:1.32.0-SNAPSHOT
+    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.0-SNAPSHOT
     restart: always
   caddy-issuer:
     configs:

--- a/examples/st/compose.yaml
+++ b/examples/st/compose.yaml
@@ -44,7 +44,7 @@ services:
       PRISM_NODE_PORT: '50053'
       REST_SERVICE_URL: http://caddy-issuer:8080/prism-agent
       SECRET_STORAGE_BACKEND: postgres
-    image: ghcr.io/hyperledger/identus-cloud-agent:1.32.0-SNAPSHOT
+    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.0-SNAPSHOT
     restart: always
   caddy-issuer:
     configs:


### PR DESCRIPTION
### Description: 
Update local script to consume metadata endpoint in the issuance flow. Next, we need to integrate this metadata to `credential` and `credential_offer` endpoint to make this fully functional.

### Alternatives Considered (optional): 
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
