### PR TITLE
ci: switch Scala Steward to make the PRs as the hyperledger-bot

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -17,9 +17,12 @@ jobs:
       - uses: crazy-max/ghaction-import-gpg@v3
         id: import_gpg
         with:
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-private-key: ${{ secrets.HYP_BOT_GPG_PRIVATE }}
+          passphrase: ${{ secrets.HYP_BOT_GPG_PASSWORD }}
           git-user-signingkey: true
           git-commit-gpgsign: true
+          git_config_global: true
+          git_tag_gpgsign: true
 
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,17 +1,23 @@
-buildRoots = [ "." ]
+buildRoots = ["."]
 
 pullRequests.grouping = [
-  { name = "all", title = "build: scala-steward dependency updates", "filter" = [{"group" = "*"}] }
+  {name = "tapir", title = "build: tapir dependency updates", "filter" = [{"group" = "com.softwaremill.sttp.tapir"}]},
+  {name = "zio", title = "build: zio dependency updates", "filter" = [{"group" = "dev.zio"}]},
+  {name = "dal", title = "build: DAL dependency update", "filter" = [{"group" = "io.getquill"}, {"group" = "flywaydb"}, {"group" = "org.postgresql"}, {"group" = "org.tpolecat"}]},
+  {name = "protobuf", title = "build: protobuf dependency update", "filter" = [{"group" = "com.thesamet*"}]},
+  {name = "sbt", title = "build: sbt and plugins dependency update", "filter" = [{"group" = "com.eed3si9n"}, {"group" = "com.github.sbt"}, {"group" = "org.scala-sbt"}, {"group" = "org.scalameta"}, {"group" = "org.scoverage"}]},
+  {name = "internal", title = "build: internal dependency updates", "filter" = [{"group" = "io.iohk.atala*"}, {"group" = "org.hyperledger.identus*"}]},
+  {name = "all", title = "build: scala-steward dependency updates", "filter" = [{"group" = "*"}]}
 ]
 
 updates.ignore = [
-#   { groupId = "com.softwaremill.sttp.tapir", artifactId = "tapir-json-zio" }, #TODO
-  { groupId = "com.github.dasniko", artifactId = "testcontainers-keycloak" }, #TODO
-  { groupId = "org.keycloak", artifactId = "keycloak-authz-client" }, #TODO
-  { groupId = "dev.zio", artifactId = "zio-interop-cats" } #TODO
+  #   { groupId = "com.softwaremill.sttp.tapir", artifactId = "tapir-json-zio" }, #TODO
+  {groupId = "com.github.dasniko", artifactId = "testcontainers-keycloak"}, #TODO
+  {groupId = "org.keycloak", artifactId = "keycloak-authz-client"}, #TODO
+  {groupId = "dev.zio", artifactId = "zio-interop-cats"} #TODO
 ]
 
 # If set, Scala Steward will only create or update `n` PRs each time it runs (see `pullRequests.frequency` above).
 # Useful if running frequently and/or CI build are costly
 # Default: null
-updates.limit = 10
+updates.limit = 5

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -10,3 +10,8 @@ updates.ignore = [
   { groupId = "org.keycloak", artifactId = "keycloak-authz-client" }, #TODO
   { groupId = "dev.zio", artifactId = "zio-interop-cats" } #TODO
 ]
+
+# If set, Scala Steward will only create or update `n` PRs each time it runs (see `pullRequests.frequency` above).
+# Useful if running frequently and/or CI build are costly
+# Default: null
+updates.limit = 10

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@
   <a href="https://github.com/hyperledger/identus-cloud-agent/actions/workflows/unit-tests.yml"> <img src="https://github.com/hyperledger/identus-cloud-agent/actions/workflows/unit-tests.yml/badge.svg" alt="Unit tests" /> </a>
   <a href="https://github.com/hyperledger/identus-cloud-agent/actions/workflows/integration-tests.yml"> <img src="https://github.com/hyperledger/identus-cloud-agent/actions/workflows/integration-tests.yml/badge.svg" alt="End-to-end tests" /> </a>
   <a href="https://github.com/hyperledger/identus-cloud-agent/actions/workflows/performance-tests.yml"> <img src="https://github.com/hyperledger/identus-cloud-agent/actions/workflows/performance-tests.yml/badge.svg" alt="Performance tests" /> </a>
+  <a href="https://scala-steward.org">
+      <img src="https://img.shields.io/badge/Scala_Steward-helping-blue.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAMAAAARSr4IAAAAVFBMVEUAAACHjojlOy5NWlrKzcYRKjGFjIbp293YycuLa3pYY2LSqql4f3pCUFTgSjNodYRmcXUsPD/NTTbjRS+2jomhgnzNc223cGvZS0HaSD0XLjbaSjElhIr+AAAAAXRSTlMAQObYZgAAAHlJREFUCNdNyosOwyAIhWHAQS1Vt7a77/3fcxxdmv0xwmckutAR1nkm4ggbyEcg/wWmlGLDAA3oL50xi6fk5ffZ3E2E3QfZDCcCN2YtbEWZt+Drc6u6rlqv7Uk0LdKqqr5rk2UCRXOk0vmQKGfc94nOJyQjouF9H/wCc9gECEYfONoAAAAASUVORK5CYII=" alt="Scala Steward badge">
+  </a>
+
+
 </p>
 <hr>
 


### PR DESCRIPTION
### Description: 
- change Scala Steward to sign the commits as the Hyperledger Bot
- limit the number of updates in each PR to 10
- add Scala Steward badge to the README.md

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
