### PR TITLE
fix: expose new key types in rest api

### DIFF
--- a/castor/src/main/scala/org/hyperledger/identus/castor/core/model/error/package.scala
+++ b/castor/src/main/scala/org/hyperledger/identus/castor/core/model/error/package.scala
@@ -23,8 +23,7 @@ package object error {
     final case class TooManyDidPublicKeyAccess(limit: Int, access: Option[Int]) extends OperationValidationError
     final case class TooManyDidServiceAccess(limit: Int, access: Option[Int]) extends OperationValidationError
     final case class InvalidArgument(msg: String) extends OperationValidationError
-    final case class InvalidPublicKeyData(ids: Seq[String]) extends OperationValidationError
-    final case class InvalidMasterKeyType(ids: Seq[String]) extends OperationValidationError
+    final case class InvalidMasterKeyData(ids: Seq[String]) extends OperationValidationError
   }
 
 }

--- a/castor/src/main/scala/org/hyperledger/identus/castor/core/util/DIDOperationValidator.scala
+++ b/castor/src/main/scala/org/hyperledger/identus/castor/core/util/DIDOperationValidator.scala
@@ -8,7 +8,6 @@ import org.hyperledger.identus.shared.crypto.Apollo
 import zio.*
 
 import scala.collection.immutable.ArraySeq
-import scala.util.Failure
 
 object DIDOperationValidator {
   final case class Config(

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/controller/http/ManagedDID.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/controller/http/ManagedDID.scala
@@ -203,13 +203,10 @@ final case class ManagedDIDKeyTemplate(
     @description(ManagedDIDKeyTemplate.annotations.purpose.description)
     @encodedExample(ManagedDIDKeyTemplate.annotations.purpose.example)
     purpose: Purpose,
-    // @description(ManagedDIDKeyTemplate.annotations.curve.description)
-    // @encodedExample(ManagedDIDKeyTemplate.annotations.curve.example)
-    // curve: Option[Curve]
-) {
-  // TODO: this curve option is hidden for now, to be added back after integration test with node
-  def curve: Option[Curve] = None
-}
+    @description(ManagedDIDKeyTemplate.annotations.curve.description)
+    @encodedExample(ManagedDIDKeyTemplate.annotations.curve.example)
+    curve: Option[Curve]
+)
 
 object ManagedDIDKeyTemplate {
   object annotations {

--- a/pollux/vc-jwt/src/main/scala/org/hyperledger/identus/pollux/vc/jwt/DidJWT.scala
+++ b/pollux/vc-jwt/src/main/scala/org/hyperledger/identus/pollux/vc/jwt/DidJWT.scala
@@ -7,8 +7,6 @@ import com.nimbusds.jose.jwk.{Curve, ECKey}
 import com.nimbusds.jwt.{JWTClaimsSet, SignedJWT}
 import io.circe.*
 import zio.*
-import pdi.jwt.algorithms.JwtECDSAAlgorithm
-import pdi.jwt.{JwtAlgorithm, JwtCirce}
 
 import java.security.*
 


### PR DESCRIPTION
### Description: 
Expose ability to select key types when creating / updating managed DID. This will soon be released in order to publish the TS and Kotlin client for integration testing. Also add minor alignment on the DID operation validation with Node.

### Alternatives Considered (optional): 
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
