### PR TITLE
ci: use branch name in pre-release version name

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
       },
       {
         "name": "prerelease/*",
-        "prerelease": "snapshot"
+        "prerelease": "snapshot.${name.replace(\"prerelease/\", \"\")}"
       }
     ],
     "tagFormat": "cloud-agent-v${version}",


### PR DESCRIPTION
### Description: 

When there are multiple `prerelease/*` branch, the release task will fail as the prerelease version must be unique. This PR added the branch to the prerelease tag so it has this versioning `<version>-snapshot.<branch>.<n>`

![Screenshot_2024-05-21_18-27-16](https://github.com/hyperledger/identus-cloud-agent/assets/108713642/9d986151-9e1b-46ad-ba06-4a7237ae267e)

### Alternatives Considered (optional): 
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
