### PR TITLE
docs: rebranding to the Identus, OEA->ICA

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           cd "${CLOUD_AGENT_PATH}" || exit 129
           sbt docker:publishLocal
-          echo "open_enterprise_agent_version=$(cut -d'=' -f2 version.sbt | tr -d '" ')" >> "${GITHUB_OUTPUT}"
+          echo "agent_version=$(cut -d'=' -f2 version.sbt | tr -d '" ')" >> "${GITHUB_OUTPUT}"
           echo "prism_node_version=$(grep PRISM_NODE_VERSION infrastructure/local/.env | cut -d'=' -f2 | tr -d ' ')" >> "${GITHUB_OUTPUT}"
 
       - uses: actions/setup-java@v3
@@ -74,7 +74,7 @@ jobs:
       - name: Run integration tests
         env:
           PRISM_NODE_VERSION: ${{ steps.build_local_cloud_agent.outputs.prism_node_version }}
-          OPEN_ENTERPRISE_AGENT_VERSION: ${{ steps.build_local_cloud_agent.outputs.open_enterprise_agent_version }}
+          AGENT_VERSION: ${{ steps.build_local_cloud_agent.outputs.agent_version }}
           GITHUB_ACTOR: hyperledger-bot
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         #        continue-on-error: true
@@ -85,7 +85,7 @@ jobs:
         if: always()
         env:
           PRISM_NODE_VERSION: ${{ steps.build_local_cloud_agent.outputs.prism_node_version }}
-          OPEN_ENTERPRISE_AGENT_VERSION: ${{ steps.build_local_cloud_agent.outputs.open_enterprise_agent_version }}
+          AGENT_VERSION: ${{ steps.build_local_cloud_agent.outputs.agent_version }}
           GITHUB_ACTOR: hyperledger-bot
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,11 @@
 
 # Reporting Security Issues
 
-The Identus Cloud Agent (ICA) team and community take security bugs in the components of the OEA ecosystem seriously. We appreciate your efforts to disclose your findings responsibly and will make every effort to acknowledge your contributions.
+The Identus Cloud Agent (ICA) team and community take security bugs in the components of the ICA ecosystem seriously. We appreciate your efforts to disclose your findings responsibly and will make every effort to acknowledge your contributions.
 
 To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/hyperledger/identus-cloud-agent/security/advisories/new) tab.
 
-The OEA team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+The Identus's team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
 
 Report security bugs in third-party modules to the person or team maintaining the module.
 

--- a/infrastructure/single-tenant-testing-stack/apisix/conf/apisix.yaml
+++ b/infrastructure/single-tenant-testing-stack/apisix/conf/apisix.yaml
@@ -53,7 +53,7 @@ routes:
 upstreams:
   - id: 1
     nodes:
-      "issuer-oea:8085": 1 # tapir
+      "issuer-agent:8085": 1 # tapir
     type: roundrobin
     timeout:
       connect: 900
@@ -61,7 +61,7 @@ upstreams:
       read: 900
   - id: 2
     nodes:
-      "issuer-oea:8090": 1 # didcom
+      "issuer-agent:8090": 1 # didcom
     type: roundrobin
     timeout:
       connect: 900
@@ -69,7 +69,7 @@ upstreams:
       read: 900
   - id: 3
     nodes:
-      "verifier-oea:8085": 1 # tapir
+      "verifier-agent:8085": 1 # tapir
     type: roundrobin
     timeout:
       connect: 900
@@ -77,7 +77,7 @@ upstreams:
       read: 900
   - id: 4
     nodes:
-      "verifier-oea:8090": 1 # didcom
+      "verifier-agent:8090": 1 # didcom
     type: roundrobin
     timeout:
       connect: 900
@@ -85,7 +85,7 @@ upstreams:
       read: 900
   - id: 5
     nodes:
-      "holder-oea:8085": 1 # tapir
+      "holder-agent:8085": 1 # tapir
     type: roundrobin
     timeout:
       connect: 900
@@ -93,7 +93,7 @@ upstreams:
       read: 900
   - id: 6
     nodes:
-      "holder-oea:8090": 1 # didcom
+      "holder-agent:8090": 1 # didcom
     type: roundrobin
     timeout:
       connect: 900

--- a/infrastructure/single-tenant-testing-stack/dashboards/ica-k6-detail.json
+++ b/infrastructure/single-tenant-testing-stack/dashboards/ica-k6-detail.json
@@ -19,7 +19,7 @@
           "uid": "${DS_LOKI}"
         },
         "enable": false,
-        "expr": "{compose_service=~\".*-oea\"} |= \"ERROR\"",
+        "expr": "{compose_service=~\".*-agent\"} |= \"ERROR\"",
         "iconColor": "red",
         "instant": false,
         "name": "Error in log"
@@ -210,7 +210,7 @@
                 "uid": "${DS_LOKI}"
               },
               "editorMode": "code",
-              "expr": "count_over_time({compose_service=~\".*-oea\"}[$__interval])",
+              "expr": "count_over_time({compose_service=~\".*-agent\"}[$__interval])",
               "legendFormat": "{{ compose_service }}",
               "queryType": "range",
               "refId": "A"
@@ -316,7 +316,7 @@
                 "uid": "${DS_LOKI}"
               },
               "editorMode": "code",
-              "expr": "count_over_time({compose_service=~\".*-oea\"} |= \"ERROR\" [$__interval])",
+              "expr": "count_over_time({compose_service=~\".*-agent\"} |= \"ERROR\" [$__interval])",
               "legendFormat": "{{ compose_service }}",
               "queryType": "range",
               "refId": "A"
@@ -660,7 +660,7 @@
                 "uid": "${DS_LOKI}"
               },
               "editorMode": "code",
-              "expr": "{compose_service=~\".*-oea\"} |= \"ERROR\"",
+              "expr": "{compose_service=~\".*-agent\"} |= \"ERROR\"",
               "hide": false,
               "queryType": "range",
               "refId": "B"

--- a/infrastructure/single-tenant-testing-stack/dashboards/ica-k8s-overview.json
+++ b/infrastructure/single-tenant-testing-stack/dashboards/ica-k8s-overview.json
@@ -19,7 +19,7 @@
           "uid": "${DS_LOKI}"
         },
         "enable": false,
-        "expr": "{compose_service=~\".*-oea\"} |= \"ERROR\"",
+        "expr": "{compose_service=~\".*-agent\"} |= \"ERROR\"",
         "iconColor": "red",
         "instant": false,
         "name": "Error in log"
@@ -213,7 +213,7 @@
             "uid": "${DS_LOKI}"
           },
           "editorMode": "code",
-          "expr": "count_over_time({compose_service=~\".*-oea\"}[$__interval])",
+          "expr": "count_over_time({compose_service=~\".*-agent\"}[$__interval])",
           "legendFormat": "{{ compose_service }}",
           "queryType": "range",
           "refId": "A"
@@ -319,7 +319,7 @@
             "uid": "${DS_LOKI}"
           },
           "editorMode": "code",
-          "expr": "count_over_time({compose_service=~\".*-oea\"} |= \"ERROR\" [$__interval])",
+          "expr": "count_over_time({compose_service=~\".*-agent\"} |= \"ERROR\" [$__interval])",
           "legendFormat": "{{ compose_service }}",
           "queryType": "range",
           "refId": "A"
@@ -761,7 +761,7 @@
                 "uid": "${DS_LOKI}"
               },
               "editorMode": "code",
-              "expr": "{compose_service=~\".*-oea\"} |= \"ERROR\"",
+              "expr": "{compose_service=~\".*-agent\"} |= \"ERROR\"",
               "hide": false,
               "queryType": "range",
               "refId": "B"

--- a/infrastructure/single-tenant-testing-stack/docker-compose.yml
+++ b/infrastructure/single-tenant-testing-stack/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       node-db:
         condition: service_healthy
 
-  issuer-oea:
+  issuer-agent:
     image: ghcr.io/hyperledger/identus-cloud-agent:${AGENT_VERSION}
     environment:
       POLLUX_DB_HOST: issuer-db
@@ -135,7 +135,7 @@ services:
       prism-node:
         condition: service_started
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://issuer-oea:8085/_system/health"]
+      test: ["CMD", "curl", "-f", "http://issuer-agent:8085/_system/health"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -154,7 +154,7 @@ services:
     ports:
       - 9095:9095
 
-  verifier-oea:
+  verifier-agent:
     image: ghcr.io/hyperledger/identus-cloud-agent:${AGENT_VERSION}
     environment:
       POLLUX_DB_HOST: verifier-db
@@ -205,28 +205,28 @@ services:
       prism-node:
         condition: service_started
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://verifier-oea:8085/_system/health"]
+      test: ["CMD", "curl", "-f", "http://verifier-agent:8085/_system/health"]
       interval: 30s
       timeout: 10s
       retries: 5
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
-  issuer-oea-postgres-exporter:
+  issuer-agent-postgres-exporter:
     image: quay.io/prometheuscommunity/postgres-exporter
     ports:
       - "9995:9187"
     environment:
       - DATA_SOURCE_NAME=postgresql://postgres:postgres@holder-db:5432/postgres?sslmode=disable
 
-  holder-oea-postgres-exporter:
+  holder-agent-postgres-exporter:
     image: quay.io/prometheuscommunity/postgres-exporter
     ports:
       - "9996:9187"
     environment:
       - DATA_SOURCE_NAME=postgresql://postgres:postgres@issuer-db:5432/postgres?sslmode=disable
 
-  holder-oea:
+  holder-agent:
     image: ghcr.io/hyperledger/identus-cloud-agent:${AGENT_VERSION}
     environment:
       POLLUX_DB_HOST: holder-db
@@ -277,7 +277,7 @@ services:
       prism-node:
         condition: service_started
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://holder-oea:8085/_system/health"]
+      test: ["CMD", "curl", "-f", "http://holder-agent:8085/_system/health"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -304,9 +304,9 @@ services:
     ports:
       - "${PORT}:9080/tcp"
     depends_on:
-      - issuer-oea
-      - verifier-oea
-      - holder-oea
+      - issuer-agent
+      - verifier-agent
+      - holder-agent
 
 volumes:
   issuer_pg_data_db:

--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -1,6 +1,6 @@
 # Integration Tests
 
-This directory contains the integration tests for the Open Enterprise Agent (OEA).
+This directory contains the integration tests for the Identus Cloud Agent (ICA).
 
 ## Main concepts
 
@@ -9,7 +9,7 @@ The integration tests are written in Kotlin, and use the following tools and lib
 1. [Serenity BDD](https://serenity-bdd.github.io/) for test execution engine
 2. [Hoplite](https://github.com/sksamuel/hoplite) for configuration management
 3. [Ktor](https://ktor.io/) for HTTP listener (async receiver for webhook messages)
-4. [PRISM Kotlin client](https://github.com/hyperledger-labs/open-enterprise-agent/packages/1919198) for OEA API models.
+4. [Identus Cloud Agent Client Kotlin](https://github.com/hyperledger/identus-cloud-agent/packages/2135556) for ICA API models.
 5. [Atala Automation](https://github.com/input-output-hk/atala-automation/) for general testing helpers.
 6. [Awaitility](http://www.awaitility.org/) for asynchronous operations waiting.
 7. [TestContainers](https://www.testcontainers.org/) for Docker containers management.
@@ -62,16 +62,16 @@ Here are some rules to follow when writing the tests:
 
 ## System under test
 
-The main idea of the framework is to test the OEA as a black box.
+The main idea of the framework is to test the ICA as a black box.
 
-The tests interact with the OEA through the API and webhook messages.
+The tests interact with the ICA through the API and webhook messages.
 
 <p align="center">
 <img src="docs/static/system_under_test.png" alt="Screenplay pattern overview" width="800"/><br>
 <em>Pic. 2. Overview of the system under test. Roles, Agents and Services communication.</em>
 </p>
 
-### OEA Roles in Tests
+### ICA Roles in Tests
 
 | Role     | Description                                           |
 |----------|-------------------------------------------------------|
@@ -80,12 +80,12 @@ The tests interact with the OEA through the API and webhook messages.
 | Verifier | Verifies the credentials presented by the holder.     |
 | Admin    | Performs specific administrative tasks                |
 
-- Each OEA can play multiple roles simultaneously after multitenancy is implemented.
-- OEAs can be created on-the-fly or use existing ones, regardless of their origin (local or cloud).
+- Each ICA can play multiple roles simultaneously after multitenancy is implemented.
+- ICAs can be created on-the-fly or use existing ones, regardless of their origin (local or cloud).
 
-### OEA Configurations
+### ICA Configurations
 
-Each OEA can use different configurations for:
+Each ICA can use different configurations for:
 
 | Configuration  | Options                                                               |
 |----------------|-----------------------------------------------------------------------|
@@ -109,7 +109,7 @@ In this section, we will describe the configuration options and their purpose.
 
 The configuration files are divided into the following sections:
 * `services`: contains the configuration for the services (PRISM Node, Keycloak, Vault) that will be started and can be consumed by `agents` if specified.
-* `agents`: contains the configuration for the agents (OEA) that will be started. By default, all agents will be destroyed after the test run is finished.
+* `agents`: contains the configuration for the agents (ICA) that will be started. By default, all agents will be destroyed after the test run is finished.
 * `roles`: contains the configuration for the roles (Issuer, Holder, Verifier, Admin). A role can be assigned to one or more agents that we set in `agents` section or already running locally or in the cloud.
 
 > You could keep services and agents running for debugging purposes
@@ -180,7 +180,7 @@ There is a special `agents` section in the configuration file to specify the age
 `TestContainers` are in use for this purpose.
 
 To configure the agent, you need to specify the following options:
-* `version`: the version of the OEA docker image to use.
+* `version`: the version of the ICA docker image to use.
 * `http_port`: the port to expose for the HTTP API.
 * `didcomm_port`: the port to expose for the DIDComm API.
 * `auth_enabled`: whether API key authentication is enabled for this agent.
@@ -198,14 +198,14 @@ Here is an example of the `agents` section that configures two agents, one with 
 # Specify agents that are required to be created before running tests
 agents = [
     {
-        version = "${OPEN_ENTERPRISE_AGENT_VERSION}"
+        version = "${AGENT_VERSION}"
         http_port = 8080
         didcomm_port = 7080
         auth_enabled = true
         prism_node = ${services.prism_node}
     },
     {
-        version = "${OPEN_ENTERPRISE_AGENT_VERSION}"
+        version = "${AGENT_VERSION}"
         http_port = 8090
         didcomm_port = 7090
         auth_enabled = true
@@ -333,7 +333,7 @@ Forwarding                    https://90e7-2001-818-dce2-c000-9c53-d0a3-15f2-ca5
 After that, you could configure your local agent as follows to provide the required URLs:
 ```yaml
     {
-        version = "${OPEN_ENTERPRISE_AGENT_VERSION}"
+        version = "${AGENT_VERSION}"
         http_port = 7080
         didcomm_port = 7070
         didcomm_service_url = "https://6908-2001-818-dce2-c000-9c53-d0a3-15f2-ca59.ngrok-free.app"
@@ -394,10 +394,10 @@ Here is an example of the agent configuration for sandbox environment:
 The following variables must be set before running the tests:
 * `TESTS_CONFIG`: path to the configuration file to use, relative to `resources` directory. Default to `/configs/basic.conf`.
 * `PRISM_NODE_VERSION`: version of the PRISM Node docker image to use.
-* `OPEN_ENTERPRISE_AGENT_VERSION`: version of the OEA docker image to use.
+* `AGENT_VERSION`: version of the ICA docker image to use.
 
 ```shell
-TESTS_CONFIG=/configs/basic.conf PRISM_NODE_VERSION=2.2.1 OPEN_ENTERPRISE_AGENT_VERSION=1.30.1 ./gradlew test
+TESTS_CONFIG=/configs/basic.conf PRISM_NODE_VERSION=2.2.1 AGENT_VERSION=1.30.1 ./gradlew test
 ```
 
 > Please note: there is no need to pass environment variables if you're using already running agents.
@@ -414,7 +414,7 @@ To simplify the execution, each configuration file creates a new `gradle` task. 
 It's possible to execute the configuration file as
 
 ```shell
-PRISM_NODE_VERSION=2.2.1 OPEN_ENTERPRISE_AGENT_VERSION=1.30.1 ./gradlew test_basic
+PRISM_NODE_VERSION=2.2.1 AGENT_VERSION=1.30.1 ./gradlew test_basic
 ```
 
 Also, it's possible to execute the integration tests to all configurations files. The task is named `regression`, it should take a lot of time to execute.
@@ -422,7 +422,7 @@ Also, it's possible to execute the integration tests to all configurations files
 Note: report is not working due constrains in Serenity BDD reporting system.
 
 ```shell
-PRISM_NODE_VERSION=2.2.1 OPEN_ENTERPRISE_AGENT_VERSION=1.30.1 ./gradlew regression
+PRISM_NODE_VERSION=2.2.1 AGENT_VERSION=1.30.1 ./gradlew regression
 ```
 
 ### Running scenarios in IntelliJ IDEA
@@ -476,7 +476,7 @@ After that, follow the next steps:
 5. Change the Glue field to the root package of your project (or of your step definitions)
 6. Click Apply
 
-> Please note: you still need to set the `PRISM_NODE_VERSION` and `OPEN_ENTERPRISE_AGENT_VERSION`
+> Please note: you still need to set the `PRISM_NODE_VERSION` and `AGENT_VERSION`
 > environment variables for this option to work if you don't use already running agents!
 
 ## Analysing reports

--- a/tests/integration-tests/build.gradle.kts
+++ b/tests/integration-tests/build.gradle.kts
@@ -84,7 +84,7 @@ afterEvaluate {
             testLogging.showStandardStreams = true
             systemProperty("TESTS_CONFIG", "/configs/$fileName.conf")
             systemProperty("PRISM_NODE_VERSION", System.getenv("PRISM_NODE_VERSION") ?: "")
-            systemProperty("OPEN_ENTERPRISE_AGENT_VERSION", System.getenv("OPEN_ENTERPRISE_AGENT_VERSION") ?: "")
+            systemProperty("AGENT_VERSION", System.getenv("AGENT_VERSION") ?: "")
             systemProperty("cucumber.filter.tags", System.getProperty("cucumber.filter.tags"))
             finalizedBy("aggregate", "reports")
         }

--- a/tests/integration-tests/src/test/kotlin/config/services/Agent.kt
+++ b/tests/integration-tests/src/test/kotlin/config/services/Agent.kt
@@ -23,7 +23,7 @@ data class Agent(
 
     init {
         val env = mutableMapOf(
-            "OPEN_ENTERPRISE_AGENT_VERSION" to version,
+            "AGENT_VERSION" to version,
             "API_KEY_ENABLED" to authEnabled.toString(),
             "AGENT_DIDCOMM_PORT" to didcommPort.toString(),
             "DIDCOMM_SERVICE_URL" to (didcommServiceUrl ?: "http://host.docker.internal:$didcommPort"),

--- a/tests/integration-tests/src/test/resources/configs/basic.conf
+++ b/tests/integration-tests/src/test/resources/configs/basic.conf
@@ -9,7 +9,7 @@ services = {
 # Specify agents that are required to be created before running tests
 agents = [
     {
-        version = "${OPEN_ENTERPRISE_AGENT_VERSION}"
+        version = "${AGENT_VERSION}"
         http_port = 8080
         didcomm_port = 7080
         auth_enabled = true

--- a/tests/integration-tests/src/test/resources/configs/mt_keycloak.conf
+++ b/tests/integration-tests/src/test/resources/configs/mt_keycloak.conf
@@ -12,7 +12,7 @@ services = {
 # Specify agents that are required to be created before running tests
 agents = [
     {
-        version = "${OPEN_ENTERPRISE_AGENT_VERSION}"
+        version = "${AGENT_VERSION}"
         http_port = 8080
         didcomm_port = 7080
         auth_enabled = false

--- a/tests/integration-tests/src/test/resources/configs/mt_keycloak_agent_role.conf
+++ b/tests/integration-tests/src/test/resources/configs/mt_keycloak_agent_role.conf
@@ -12,7 +12,7 @@ services = {
 # Specify agents that are required to be created before running tests
 agents = [
     {
-        version = "${OPEN_ENTERPRISE_AGENT_VERSION}"
+        version = "${AGENT_VERSION}"
         http_port = 8080
         didcomm_port = 7080
         auth_enabled = false

--- a/tests/integration-tests/src/test/resources/configs/mt_keycloak_vault.conf
+++ b/tests/integration-tests/src/test/resources/configs/mt_keycloak_vault.conf
@@ -16,7 +16,7 @@ services = {
 # Specify agents that are required to be created before running tests
 agents = [
     {
-        version = "${OPEN_ENTERPRISE_AGENT_VERSION}"
+        version = "${AGENT_VERSION}"
         http_port = 8080
         didcomm_port = 7080
         auth_enabled = false

--- a/tests/integration-tests/src/test/resources/configs/mt_vault_approle.conf
+++ b/tests/integration-tests/src/test/resources/configs/mt_vault_approle.conf
@@ -13,7 +13,7 @@ services = {
 # Specify agents that are required to be created before running tests
 agents = [
     {
-        version = "${OPEN_ENTERPRISE_AGENT_VERSION}"
+        version = "${AGENT_VERSION}"
         http_port = 8080
         didcomm_port = 7080
         auth_enabled = true

--- a/tests/integration-tests/src/test/resources/configs/mt_vault_token.conf
+++ b/tests/integration-tests/src/test/resources/configs/mt_vault_token.conf
@@ -13,7 +13,7 @@ services = {
 # Specify agents that are required to be created before running tests
 agents = [
     {
-        version = "${OPEN_ENTERPRISE_AGENT_VERSION}"
+        version = "${AGENT_VERSION}"
         http_port = 8080
         didcomm_port = 7080
         auth_enabled = true

--- a/tests/integration-tests/src/test/resources/configs/two_agents_basic.conf
+++ b/tests/integration-tests/src/test/resources/configs/two_agents_basic.conf
@@ -9,14 +9,14 @@ services = {
 # Specify agents that are required to be created before running tests
 agents = [
     {
-        version = "${OPEN_ENTERPRISE_AGENT_VERSION}"
+        version = "${AGENT_VERSION}"
         http_port = 8080
         didcomm_port = 7080
         auth_enabled = true
         prism_node = ${services.prism_node}
     },
     {
-        version = "${OPEN_ENTERPRISE_AGENT_VERSION}"
+        version = "${AGENT_VERSION}"
         http_port = 8090
         didcomm_port = 7090
         auth_enabled = true

--- a/tests/integration-tests/src/test/resources/configs/two_agents_sharing_keycloak.conf
+++ b/tests/integration-tests/src/test/resources/configs/two_agents_sharing_keycloak.conf
@@ -12,7 +12,7 @@ services = {
 # Specify agents that are required to be created before running tests
 agents = [
     {
-        version = "${OPEN_ENTERPRISE_AGENT_VERSION}"
+        version = "${AGENT_VERSION}"
         http_port = 8080
         didcomm_port = 7080
         auth_enabled = false
@@ -20,7 +20,7 @@ agents = [
         keycloak = ${services.keycloak}
     },
     {
-        version = "${OPEN_ENTERPRISE_AGENT_VERSION}"
+        version = "${AGENT_VERSION}"
         http_port = 8090
         didcomm_port = 7090
         auth_enabled = false

--- a/tests/integration-tests/src/test/resources/containers/agent.yml
+++ b/tests/integration-tests/src/test/resources/containers/agent.yml
@@ -22,7 +22,7 @@ services:
 
   # Open Enterprise Agent
   open-enterprise-agent:
-    image: ghcr.io/hyperledger/identus-cloud-agent:${OPEN_ENTERPRISE_AGENT_VERSION}
+    image: ghcr.io/hyperledger/identus-cloud-agent:${AGENT_VERSION}
     environment:
       PRISM_NODE_HOST: host.docker.internal
       PRISM_NODE_PORT:


### PR DESCRIPTION
### Description: 
- updated terms OEA (Open Enterprise Agent) to ICA (Identus Cloud Agent)
- updated suffixes `-oea` to `-ica` or `-agent`

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
