### PR TITLE
ci: fail the build when the megalinter found the issues [skip ci]

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -73,8 +73,10 @@ jobs:
           committer: "Hyperledger Bot <hyperledger-bot@hyperledger.org>"
           author: "Hyperledger Bot <hyperledger-bot@hyperledger.org>"
 
-      - name: Create PR output
+      - name: Create PR output and fail the build
         if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
         run: |
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+          echo "Failing the build to prevent PR merge to main. Review the PR and merge it manually"
+          exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,9 +37,9 @@ jobs:
       - name: MegaLinter
         id: ml
         uses: oxsecurity/megalinter@v7.1.0
-        continue-on-error: true
 
       - name: Archive production artifacts
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: Mega-Linter reports
@@ -49,6 +49,7 @@ jobs:
           overwrite: true
 
       - uses: crazy-max/ghaction-import-gpg@v3
+        if: failure() && steps.ml.outputs.has_updated_sources == 1
         id: import_gpg
         with:
           gpg-private-key: ${{ secrets.HYP_BOT_GPG_PRIVATE }}
@@ -61,7 +62,7 @@ jobs:
       # Create pull request if applicable (for now works only on PR from same repository, not from forks)
       - name: Create Pull Request with applied fixes
         id: cpr
-        if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
+        if: failure() && steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -73,10 +74,8 @@ jobs:
           committer: "Hyperledger Bot <hyperledger-bot@hyperledger.org>"
           author: "Hyperledger Bot <hyperledger-bot@hyperledger.org>"
 
-      - name: Create PR output and fail the build
-        if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
+      - name: Create PR output
+        if: failure() && steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
         run: |
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
-          echo "Failing the build to prevent PR merge to main. Review the PR and merge it manually"
-          exit 1


### PR DESCRIPTION
### Description: 
- fix the megalinter flow to fail the build when the errors found and auto-fixes are applied

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
