### PR TITLE
fix: integrate issuer metadata in oid4vci credential endpoint

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -59,7 +59,7 @@ PRE_COMMANDS:
 MARKDOWN_MARKDOWN_LINK_CHECK_FILTER_REGEX_EXCLUDE: "CHANGELOG.md"
 MARKDOWN_MARKDOWNLINT_FILTER_REGEX_EXCLUDE: "CHANGELOG.md"
 SQL_SQL_LINT_ARGUMENTS: -d postgres --ignore-errors=postgres-invalid-alter-option,postgres-invalid-create-option,postgres-invalid-drop-option
-YAML_YAMLLINT_FILTER_REGEX_EXCLUDE: "infrastructure/charts/agent/*|cloud-agent/service/api/http/*"
-YAML_PRETTIER_FILTER_REGEX_EXCLUDE: "infrastructure/charts/agent/*|cloud-agent/service/api/http/*"
+YAML_YAMLLINT_FILTER_REGEX_EXCLUDE: "infrastructure/charts/agent/*|cloud-agent/service/api/http/*|examples/*"
+YAML_PRETTIER_FILTER_REGEX_EXCLUDE: "infrastructure/charts/agent/*|cloud-agent/service/api/http/*|examples/*"
 YAML_V8R_FILTER_REGEX_EXCLUDE: "infrastructure/charts/agent/*"
 JAVASCRIPT_STANDARD_FILTER_REGEX_EXCLUDE: "tests/performance-tests/agent-performance-tests-k6/src/k6chaijs.js"

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/CredentialIssuerEndpoints.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/CredentialIssuerEndpoints.scala
@@ -1,8 +1,6 @@
 package org.hyperledger.identus.oid4vci
 
 import org.hyperledger.identus.api.http.{EndpointOutputs, ErrorResponse, RequestContext}
-import org.hyperledger.identus.castor.controller.http.DIDInput
-import org.hyperledger.identus.castor.controller.http.DIDInput.didRefPathSegment
 import org.hyperledger.identus.iam.authentication.apikey.ApiKeyCredentials
 import org.hyperledger.identus.iam.authentication.apikey.ApiKeyEndpointSecurityLogic.apiKeyHeader
 import org.hyperledger.identus.iam.authentication.oidc.JwtCredentials
@@ -65,12 +63,12 @@ object CredentialIssuerEndpoints {
 
   val credentialEndpoint: Endpoint[
     JwtCredentials,
-    (RequestContext, String, CredentialRequest),
+    (RequestContext, UUID, CredentialRequest),
     ExtendedErrorResponse,
     CredentialResponse,
     Any
   ] = baseEndpoint.post
-    .in(didRefPathSegment / "credentials")
+    .in(issuerIdPathSegment / "credentials")
     .in(jsonBody[CredentialRequest])
     .securityIn(jwtAuthHeader)
     .out(

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/CredentialIssuerServerEndpoints.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/CredentialIssuerServerEndpoints.scala
@@ -2,10 +2,10 @@ package org.hyperledger.identus.oid4vci
 
 import org.hyperledger.identus.LogUtils.*
 import org.hyperledger.identus.agent.walletapi.model.BaseEntity
-import org.hyperledger.identus.api.http.{ErrorResponse, RequestContext}
+import org.hyperledger.identus.api.http.ErrorResponse
 import org.hyperledger.identus.iam.authentication.{Authenticator, Authorizer, DefaultAuthenticator, SecurityLogic}
 import org.hyperledger.identus.oid4vci.controller.CredentialIssuerController
-import org.hyperledger.identus.oid4vci.http.{CredentialErrorResponse, CredentialRequest, NonceResponse}
+import org.hyperledger.identus.oid4vci.http.{CredentialErrorResponse, NonceResponse}
 import sttp.tapir.ztapir.*
 import zio.*
 
@@ -22,10 +22,10 @@ case class CredentialIssuerServerEndpoints(
           .mapError(Left[ErrorResponse, CredentialErrorResponse])
       )
       .serverLogic { wac =>
-        { case (rc: RequestContext, didRef: String, request: CredentialRequest) =>
+        { case (rc, issuerId, request) =>
           ZIO.succeed(request).debug("credentialRequest") *>
             credentialIssuerController
-              .issueCredential(rc, didRef, request)
+              .issueCredential(rc, issuerId, request)
               .logTrace(rc)
         }
       }

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/controller/CredentialIssuerController.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/controller/CredentialIssuerController.scala
@@ -5,7 +5,7 @@ import org.hyperledger.identus.api.http.ErrorResponse.badRequest
 import org.hyperledger.identus.api.http.ErrorResponse.internalServerError
 import org.hyperledger.identus.api.http.{ErrorResponse, RequestContext}
 import org.hyperledger.identus.api.util.PaginationUtils
-import org.hyperledger.identus.castor.core.model.did.{CanonicalPrismDID, PrismDID}
+import org.hyperledger.identus.castor.core.model.did.PrismDID
 import org.hyperledger.identus.oid4vci.CredentialIssuerEndpoints.ExtendedErrorResponse
 import org.hyperledger.identus.oid4vci.http.*
 import org.hyperledger.identus.oid4vci.http.CredentialErrorCode.*
@@ -22,7 +22,7 @@ import scala.language.implicitConversions
 trait CredentialIssuerController {
   def issueCredential(
       ctx: RequestContext,
-      didRef: String,
+      issuerId: UUID,
       credentialRequest: CredentialRequest
   ): IO[ExtendedErrorResponse, CredentialResponse]
 
@@ -140,26 +140,9 @@ case class CredentialIssuerControllerImpl(
       .attempt(URI.create(url).toURL())
       .mapError(ue => badRequest(detail = Some(s"Invalid URL: $url")))
 
-  private def parseIssuerDID[E](didRef: String, errorFn: (String, String) => E): IO[E, CanonicalPrismDID] = {
-    for {
-      prismDID <- ZIO
-        .fromEither(PrismDID.fromString(didRef))
-        .mapError[E](didParsingError => errorFn(didRef, didParsingError))
-    } yield prismDID.asCanonical
-  }
-
-  private def parseIssuerDIDBasicError(didRef: String): IO[ErrorResponse, CanonicalPrismDID] =
-    parseIssuerDID(
-      didRef,
-      (didRef, detail) => ErrorResponse.badRequest(detail = Some(s"Invalid DID input $didRef. $detail"))
-    )
-
-  private def parseIssuerDIDOidc4vcError(difRef: String): IO[ExtendedErrorResponse, CanonicalPrismDID] =
-    parseIssuerDID(difRef, badRequestInvalidDID)
-
   def issueCredential(
       ctx: RequestContext,
-      didRef: String,
+      issuerId: UUID,
       credentialRequest: CredentialRequest
   ): IO[ExtendedErrorResponse, CredentialResponse] = {
     credentialRequest match
@@ -170,13 +153,13 @@ case class CredentialIssuerControllerImpl(
             credentialResponseEncryption,
             credentialDefinition
           ) =>
-        issueJwtCredential(didRef, proof, credentialIdentifier, credentialDefinition, credentialResponseEncryption)
+        issueJwtCredential(issuerId, proof, credentialIdentifier, credentialDefinition, credentialResponseEncryption)
       case other: CredentialRequest => // add other formats here
         ZIO.fail(badRequestUnsupportedCredentialFormat(credentialRequest.format))
   }
 
   def issueJwtCredential(
-      didRef: String,
+      issuerId: UUID,
       maybeProof: Option[Proof],
       maybeCredentialIdentifier: Option[String],
       maybeCredentialDefinition: Option[CredentialDefinition],
@@ -185,7 +168,6 @@ case class CredentialIssuerControllerImpl(
     maybeProof match {
       case Some(JwtProof(proofType, jwt)) =>
         for {
-          canonicalPrismDID: CanonicalPrismDID <- parseIssuerDIDOidc4vcError(didRef)
           _ <- ZIO
             .ifZIO(credentialIssuerService.verifyJwtProof(jwt))(
               ZIO.unit,
@@ -194,6 +176,10 @@ case class CredentialIssuerControllerImpl(
             .mapError { case InvalidProof(message) =>
               badRequestInvalidProof(jwt, message)
             }
+          nonce = "todo - extract jwt nonce" // TODO: validate proof and extract nonce
+          session <- credentialIssuerService
+            .getIssuanceSessionByNonce(nonce)
+            .mapError(_ => badRequestInvalidProof(jwt, "nonce is not associated to the issuance session"))
           credentialDefinition <- ZIO
             .fromOption(maybeCredentialDefinition)
             .mapError(_ => badRequestUnsupportedCredentialType("No credential definition provided"))
@@ -204,7 +190,7 @@ case class CredentialIssuerControllerImpl(
             )
           credential <- credentialIssuerService
             .issueJwtCredential(
-              canonicalPrismDID,
+              session.issuingDid,
               maybeCredentialIdentifier,
               validatedCredentialDefinition
             )
@@ -220,8 +206,11 @@ case class CredentialIssuerControllerImpl(
       credentialOfferRequest: CredentialOfferRequest
   ): ZIO[WalletAccessContext, ErrorResponse, CredentialOfferResponse] = {
     for {
+      issuingDid <- ZIO
+        .fromEither(PrismDID.fromString(credentialOfferRequest.issuingDID))
+        .mapError(e => badRequest(detail = Some(s"Invalid DID: $e")))
       resp <- credentialIssuerService
-        .createCredentialOffer(issuerId, credentialOfferRequest.claims)
+        .createCredentialOffer(issuerId, issuingDid, credentialOfferRequest.claims)
         .map(offer => CredentialOfferResponse(offer.offerUri))
         .mapError(ue =>
           internalServerError(detail = Some(s"Unexpected error while creating credential offer: ${ue.message}"))

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/domain/IssuanceSession.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/domain/IssuanceSession.scala
@@ -1,6 +1,5 @@
 package org.hyperledger.identus.oid4vci.domain
 
-import org.hyperledger.identus.castor.core.model.did.CanonicalPrismDID
 import org.hyperledger.identus.castor.core.model.did.DID
 import org.hyperledger.identus.castor.core.model.did.PrismDID
 

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/domain/IssuanceSession.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/domain/IssuanceSession.scala
@@ -2,6 +2,7 @@ package org.hyperledger.identus.oid4vci.domain
 
 import org.hyperledger.identus.castor.core.model.did.CanonicalPrismDID
 import org.hyperledger.identus.castor.core.model.did.DID
+import org.hyperledger.identus.castor.core.model.did.PrismDID
 
 import java.util.UUID
 
@@ -12,5 +13,5 @@ case class IssuanceSession(
     schemaId: Option[String],
     claims: zio.json.ast.Json,
     subjectDid: Option[DID],
-    issuingDid: CanonicalPrismDID,
+    issuingDid: PrismDID,
 )

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/http/CredentialOfferRequest.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/http/CredentialOfferRequest.scala
@@ -5,7 +5,7 @@ import sttp.tapir.json.zio.schemaForZioJsonValue
 import zio.json.{DeriveJsonDecoder, DeriveJsonEncoder, JsonDecoder, JsonEncoder}
 
 case class CredentialOfferRequest(
-    credentialConfigurationId: Option[String], // TODO: this field should be requried
+    credentialConfigurationId: String,
     issuingDID: String,
     claims: zio.json.ast.Json,
 )

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/http/CredentialOfferRequest.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/http/CredentialOfferRequest.scala
@@ -6,6 +6,7 @@ import zio.json.{DeriveJsonDecoder, DeriveJsonEncoder, JsonDecoder, JsonEncoder}
 
 case class CredentialOfferRequest(
     credentialConfigurationId: Option[String], // TODO: this field should be requried
+    issuingDID: String,
     claims: zio.json.ast.Json,
 )
 

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/http/IssuerMetadata.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/http/IssuerMetadata.scala
@@ -21,13 +21,12 @@ object IssuerMetadata {
   given decoder: JsonDecoder[IssuerMetadata] = DeriveJsonDecoder.gen
 
   def fromIssuer(
-      agentBaseUrl: URL,
+      credentialIssuerBaseUrl: URL,
       issuer: pollux.CredentialIssuer,
       credentialConfigurations: Seq[pollux.CredentialConfiguration]
   ): IssuerMetadata = {
-    val credentialIssuerBaseUrl = agentBaseUrl.toURI().resolve(s"oid4vci/issuers/${issuer.id}").toString
     IssuerMetadata(
-      credential_issuer = credentialIssuerBaseUrl,
+      credential_issuer = credentialIssuerBaseUrl.toString(),
       authorization_servers = Some(Seq(issuer.authorizationServer.toString())),
       credential_endpoint = s"$credentialIssuerBaseUrl/credentials",
       credential_configurations_supported =

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/service/OIDCCredentialIssuerService.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/service/OIDCCredentialIssuerService.scala
@@ -2,7 +2,6 @@ package org.hyperledger.identus.oid4vci.service
 
 import io.circe.Json
 import org.hyperledger.identus.agent.walletapi.storage.DIDNonSecretStorage
-import org.hyperledger.identus.castor.core.model.did.CanonicalPrismDID
 import org.hyperledger.identus.castor.core.model.did.{PrismDID, VerificationRelationship}
 import org.hyperledger.identus.oid4vci.domain.IssuanceSession
 import org.hyperledger.identus.oid4vci.http.*
@@ -12,6 +11,7 @@ import org.hyperledger.identus.pollux.vc.jwt.{DID, Issuer, JWT, JwtCredential, W
 import org.hyperledger.identus.shared.models.{WalletAccessContext, WalletId}
 import zio.*
 
+import java.net.URL
 import java.time.Instant
 import java.util.UUID
 import scala.util.Try
@@ -37,7 +37,9 @@ trait OIDCCredentialIssuerService {
   ): IO[Error, JWT]
 
   def createCredentialOffer(
+      credentialIssuerBaseUrl: URL,
       issuerId: UUID,
+      credentialConfigurationId: String,
       issuingDID: PrismDID,
       claims: zio.json.ast.Json,
   ): ZIO[WalletAccessContext, Error, CredentialOffer]
@@ -158,18 +160,21 @@ case class OIDCCredentialIssuerServiceImpl(
       .someOrFail(ServiceError(s"The IssuanceSession with the issuerState $issuerState does not exist"))
 
   override def createCredentialOffer(
+      credentialIssuerBaseUrl: URL,
       issuerId: UUID,
+      credentialConfigurationId: String,
       issuingDID: PrismDID,
       claims: zio.json.ast.Json
   ): ZIO[WalletAccessContext, OIDCCredentialIssuerService.Error, CredentialOffer] =
+    // TODO: validate claims with credential schema
     for {
       session <- buildNewIssuanceSession(issuingDID, claims)
       _ <- issuanceSessionStorage
         .start(session)
         .mapError(e => ServiceError(s"Failed to start issuance session: ${e.message}"))
     } yield CredentialOffer(
-      credential_issuer = s"http://localhost:8080/prism-agent/${issuerId}", // TODO: add issuer metadata endpoint
-      credential_configuration_ids = Seq("UniversityDegreeCredential"), // TODO: allow credential configuration CRUD
+      credential_issuer = credentialIssuerBaseUrl.toString(),
+      credential_configuration_ids = Seq(credentialConfigurationId),
       grants = Some(
         CredentialOfferGrant(
           authorization_code = CredentialOfferAuthorizationGrant(issuer_state = Some(session.issuerState))

--- a/examples/.nickel/versions.ncl
+++ b/examples/.nickel/versions.ncl
@@ -1,7 +1,7 @@
 {
   # identus
-  agent = "1.33.0-SNAPSHOT",
-  node = "2.2.1",
+  agent = "1.33.1-SNAPSHOT",
+  node = "2.4.0",
   # 3rd party
   caddy = "2.7.6-alpine",
   mockServer = "5.15.0",

--- a/examples/mt-keycloak-vault/compose.yaml
+++ b/examples/mt-keycloak-vault/compose.yaml
@@ -53,7 +53,7 @@ services:
       SECRET_STORAGE_BACKEND: vault
       VAULT_ADDR: http://vault-default:8200
       VAULT_TOKEN: admin
-    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.0-SNAPSHOT
+    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.1-SNAPSHOT
     restart: always
   caddy-default:
     configs:
@@ -121,7 +121,7 @@ services:
       NODE_PSQL_HOST: node-db:5432
       NODE_PSQL_PASSWORD: postgres
       NODE_PSQL_USERNAME: postgres
-    image: ghcr.io/input-output-hk/prism-node:2.2.1
+    image: ghcr.io/input-output-hk/prism-node:2.4.0
     restart: always
   node-db:
     environment:

--- a/examples/mt-keycloak/compose.yaml
+++ b/examples/mt-keycloak/compose.yaml
@@ -51,7 +51,7 @@ services:
       PRISM_NODE_PORT: '50053'
       REST_SERVICE_URL: http://caddy-default:8080/prism-agent
       SECRET_STORAGE_BACKEND: postgres
-    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.0-SNAPSHOT
+    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.1-SNAPSHOT
     restart: always
   caddy-default:
     configs:
@@ -119,7 +119,7 @@ services:
       NODE_PSQL_HOST: node-db:5432
       NODE_PSQL_PASSWORD: postgres
       NODE_PSQL_USERNAME: postgres
-    image: ghcr.io/input-output-hk/prism-node:2.2.1
+    image: ghcr.io/input-output-hk/prism-node:2.4.0
     restart: always
   node-db:
     environment:

--- a/examples/mt/compose.yaml
+++ b/examples/mt/compose.yaml
@@ -44,7 +44,7 @@ services:
       PRISM_NODE_PORT: '50053'
       REST_SERVICE_URL: http://caddy-default:8080/prism-agent
       SECRET_STORAGE_BACKEND: postgres
-    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.0-SNAPSHOT
+    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.1-SNAPSHOT
     restart: always
   caddy-default:
     configs:
@@ -85,7 +85,7 @@ services:
       NODE_PSQL_HOST: node-db:5432
       NODE_PSQL_PASSWORD: postgres
       NODE_PSQL_USERNAME: postgres
-    image: ghcr.io/input-output-hk/prism-node:2.2.1
+    image: ghcr.io/input-output-hk/prism-node:2.4.0
     restart: always
   node-db:
     environment:

--- a/examples/st-multi/compose.yaml
+++ b/examples/st-multi/compose.yaml
@@ -76,7 +76,7 @@ services:
       PRISM_NODE_PORT: '50053'
       REST_SERVICE_URL: http://caddy-holder:8081/prism-agent
       SECRET_STORAGE_BACKEND: postgres
-    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.0-SNAPSHOT
+    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.1-SNAPSHOT
     restart: always
   agent-issuer:
     depends_on:
@@ -106,7 +106,7 @@ services:
       PRISM_NODE_PORT: '50053'
       REST_SERVICE_URL: http://caddy-issuer:8080/prism-agent
       SECRET_STORAGE_BACKEND: postgres
-    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.0-SNAPSHOT
+    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.1-SNAPSHOT
     restart: always
   agent-verifier:
     depends_on:
@@ -136,7 +136,7 @@ services:
       PRISM_NODE_PORT: '50053'
       REST_SERVICE_URL: http://caddy-verifier:8082/prism-agent
       SECRET_STORAGE_BACKEND: postgres
-    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.0-SNAPSHOT
+    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.1-SNAPSHOT
     restart: always
   caddy-holder:
     configs:
@@ -237,7 +237,7 @@ services:
       NODE_PSQL_HOST: node-db:5432
       NODE_PSQL_PASSWORD: postgres
       NODE_PSQL_USERNAME: postgres
-    image: ghcr.io/input-output-hk/prism-node:2.2.1
+    image: ghcr.io/input-output-hk/prism-node:2.4.0
     restart: always
   node-db:
     environment:

--- a/examples/st-oid4vci/compose.yaml
+++ b/examples/st-oid4vci/compose.yaml
@@ -44,7 +44,7 @@ services:
       PRISM_NODE_PORT: '50053'
       REST_SERVICE_URL: http://caddy-issuer:8080/prism-agent
       SECRET_STORAGE_BACKEND: postgres
-    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.0-SNAPSHOT
+    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.1-SNAPSHOT
     restart: always
   caddy-issuer:
     configs:
@@ -120,7 +120,7 @@ services:
       NODE_PSQL_HOST: node-db:5432
       NODE_PSQL_PASSWORD: postgres
       NODE_PSQL_USERNAME: postgres
-    image: ghcr.io/input-output-hk/prism-node:2.2.1
+    image: ghcr.io/input-output-hk/prism-node:2.4.0
     restart: always
   node-db:
     environment:

--- a/examples/st-oid4vci/demo.py
+++ b/examples/st-oid4vci/demo.py
@@ -126,12 +126,14 @@ def issuer_create_credential_offer(claims):
 
 
 def holder_get_issuer_metadata(credential_issuer: str):
-    metadata_url = f"{CREDENTIAL_ISSUER}/.well-known/openid-credential-issuer"
+    # FIXME: override this just to make url reachable from host
+    def override_host(url):
+        return url.replace("http://caddy-issuer:8080/prism-agent", AGENT_URL)
+
+    metadata_url = override_host(f"{credential_issuer}/.well-known/openid-credential-issuer")
     response = requests.get(metadata_url).json()
-    # TODO: align docker host URL
-    response["credential_endpoint"] = response["credential_endpoint"].replace(
-        "http://caddy-issuer:8080/prism-agent", AGENT_URL
-    )
+    response["credential_endpoint"] = override_host(response["credential_endpoint"])
+    response["credential_issuer"] = override_host(response["credential_issuer"])
     return response
 
 

--- a/examples/st-oid4vci/demo.py
+++ b/examples/st-oid4vci/demo.py
@@ -116,7 +116,11 @@ def prepare_issuer():
 def issuer_create_credential_offer(claims):
     response = requests.post(
         f"{CREDENTIAL_ISSUER}/credential-offers",
-        json={"schemaId": "TODO", "claims": claims},
+        json={
+            "credentialConfigurationId": CREDENTIAL_CONFIGURATION_ID,
+            "issuingDID": CREDENTIAL_ISSUER_DID,
+            "claims": claims,
+        },
     )
     return response.json()["credentialOffer"]
 
@@ -124,8 +128,10 @@ def issuer_create_credential_offer(claims):
 def holder_get_issuer_metadata(credential_issuer: str):
     metadata_url = f"{CREDENTIAL_ISSUER}/.well-known/openid-credential-issuer"
     response = requests.get(metadata_url).json()
-    # TODO: use credential_endpoint from response
-    response["credential_endpoint"] = f"{AGENT_URL}/oid4vci/issuers/did:prism:0000000000000000000000000000000000000000000000000000000000000000/credentials"
+    # TODO: align docker host URL
+    response["credential_endpoint"] = response["credential_endpoint"].replace(
+        "http://caddy-issuer:8080/prism-agent", AGENT_URL
+    )
     return response
 
 

--- a/examples/st-vault/compose.yaml
+++ b/examples/st-vault/compose.yaml
@@ -46,7 +46,7 @@ services:
       SECRET_STORAGE_BACKEND: vault
       VAULT_ADDR: http://vault-issuer:8200
       VAULT_TOKEN: admin
-    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.0-SNAPSHOT
+    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.1-SNAPSHOT
     restart: always
   caddy-issuer:
     configs:
@@ -87,7 +87,7 @@ services:
       NODE_PSQL_HOST: node-db:5432
       NODE_PSQL_PASSWORD: postgres
       NODE_PSQL_USERNAME: postgres
-    image: ghcr.io/input-output-hk/prism-node:2.2.1
+    image: ghcr.io/input-output-hk/prism-node:2.4.0
     restart: always
   node-db:
     environment:

--- a/examples/st/compose.yaml
+++ b/examples/st/compose.yaml
@@ -44,7 +44,7 @@ services:
       PRISM_NODE_PORT: '50053'
       REST_SERVICE_URL: http://caddy-issuer:8080/prism-agent
       SECRET_STORAGE_BACKEND: postgres
-    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.0-SNAPSHOT
+    image: ghcr.io/hyperledger/identus-cloud-agent:1.33.1-SNAPSHOT
     restart: always
   caddy-issuer:
     configs:
@@ -85,7 +85,7 @@ services:
       NODE_PSQL_HOST: node-db:5432
       NODE_PSQL_PASSWORD: postgres
       NODE_PSQL_USERNAME: postgres
-    image: ghcr.io/input-output-hk/prism-node:2.2.1
+    image: ghcr.io/input-output-hk/prism-node:2.4.0
     restart: always
   node-db:
     environment:

--- a/extensions/keycloak-oid4vci/src/main/java/io/iohk/atala/keycloak/OID4VCITokenEndpoint.java
+++ b/extensions/keycloak-oid4vci/src/main/java/io/iohk/atala/keycloak/OID4VCITokenEndpoint.java
@@ -24,7 +24,7 @@ public class OID4VCITokenEndpoint extends TokenEndpoint {
     public OID4VCITokenEndpoint(KeycloakSession session, TokenManager tokenManager, EventBuilder event) {
         super(session, tokenManager, event);
         this.identusClient = new IdentusClient();
-    }
+}
 
     @Override
     public Response createTokenResponse(UserModel user, UserSessionModel userSession, ClientSessionContext clientSessionCtx,

--- a/extensions/keycloak-oid4vci/src/main/java/io/iohk/atala/keycloak/OID4VCITokenEndpoint.java
+++ b/extensions/keycloak-oid4vci/src/main/java/io/iohk/atala/keycloak/OID4VCITokenEndpoint.java
@@ -24,7 +24,7 @@ public class OID4VCITokenEndpoint extends TokenEndpoint {
     public OID4VCITokenEndpoint(KeycloakSession session, TokenManager tokenManager, EventBuilder event) {
         super(session, tokenManager, event);
         this.identusClient = new IdentusClient();
-}
+    }
 
     @Override
     public Response createTokenResponse(UserModel user, UserSessionModel userSession, ClientSessionContext clientSessionCtx,


### PR DESCRIPTION
### Description: 

Glue the issuer metadata to the credential issuer endpoint so we can proceed with the `nonce` and JWT proof.

### Alternatives Considered (optional): 
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
