### PR TITLE
ci: revert switch to the GitHub runners

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   trigger-deployment:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Parse input parameters
         id: parse-params

--- a/.github/workflows/ff-merge.yml
+++ b/.github/workflows/ff-merge.yml
@@ -7,7 +7,7 @@ name: Fast-forward merge
 # This workflow helps to merge multiple commits from PR to main branch of the repository
 # without loosing of PGP signature.
 #
-# Related GitHub discussions: 
+# Related GitHub discussions:
 # https://github.com/community/community/discussions/10410
 # https://github.com/orgs/community/discussions/5524
 
@@ -29,5 +29,5 @@ jobs:
         uses: endre-spotlab/fast-forward-js-action@2.1
         with:
           GITHUB_TOKEN: ${{ secrets.ATALA_GITHUB_TOKEN }}
-          success_message: 'Success! Fast forwarded ***target_base*** to ***source_head***! ```git checkout target_base && git merge source_head --ff-only``` '
-          failure_message: 'Failed! Cannot do fast forward!'
+          success_message: "Success! Fast forwarded ***target_base*** to ***source_head***! ```git checkout target_base && git merge source_head --ff-only``` "
+          failure_message: "Failed! Cannot do fast forward!"

--- a/.github/workflows/ff-merge.yml
+++ b/.github/workflows/ff-merge.yml
@@ -7,7 +7,7 @@ name: Fast-forward merge
 # This workflow helps to merge multiple commits from PR to main branch of the repository
 # without loosing of PGP signature.
 #
-# Related GitHub discussions:
+# Related GitHub discussions: 
 # https://github.com/community/community/discussions/10410
 # https://github.com/orgs/community/discussions/5524
 
@@ -18,7 +18,7 @@ on:
 jobs:
   fast_forward_job:
     name: Fast Forward Merge
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     if: |
       github.event.issue.pull_request != '' &&
       contains(github.event.comment.body, '/fast-forward')
@@ -29,5 +29,5 @@ jobs:
         uses: endre-spotlab/fast-forward-js-action@2.1
         with:
           GITHUB_TOKEN: ${{ secrets.ATALA_GITHUB_TOKEN }}
-          success_message: "Success! Fast forwarded ***target_base*** to ***source_head***! ```git checkout target_base && git merge source_head --ff-only``` "
-          failure_message: "Failed! Cannot do fast forward!"
+          success_message: 'Success! Fast forwarded ***target_base*** to ***source_head***! ```git checkout target_base && git merge source_head --ff-only``` '
+          failure_message: 'Failed! Cannot do fast forward!'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build-and-unit-tests:
     name: "Build and unit tests"
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     if: ${{ !contains(github.event.pull_request.title, '[skip ci]') }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This reverts commit efba1aac0be8bfdb73cbc11cdd0cc0d0aa283aea.

### Description: 

This this PR https://github.com/hyperledger/identus-cloud-agent/pull/1121, we switch to `ubuntu-latest` because our `self-hosted` were offline. Now we have our runners online, we should switch back since the CI job took much longer to execute.

- took 26m on `ubuntu-latest` https://github.com/hyperledger/identus-cloud-agent/actions/runs/9317151746
- took 16m on `self-hosted` https://github.com/hyperledger/identus-cloud-agent/actions/runs/9283779143

### Alternatives Considered (optional): 
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
