### PR TITLE
fix: Add expiration time for cloud-agent

### DIFF
--- a/cloud-agent/service/server/src/main/resources/application.conf
+++ b/cloud-agent/service/server/src/main/resources/application.conf
@@ -28,6 +28,7 @@ pollux {
     awaitConnectionThreads = 4
     awaitConnectionThreads = ${?POLLUX_DB_AWAIT_CONNECTION_THREADS}
   }
+  credentialSdJwtExpirationTime = 30 days // Default exp claim duration in days sd jwt token if not provided in credential offer
   statusListRegistry {
     # defaults to the exposed AGENT_HTTP_PORT port
     publicEndpointUrl = "http://localhost:"${agent.httpEndpoint.http.port}

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/config/AppConfig.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/config/AppConfig.scala
@@ -68,6 +68,7 @@ object ValidatedVaultConfig {
 
 final case class PolluxConfig(
     database: DatabaseConfig,
+    credentialSdJwtExpirationTime: Duration,
     statusListRegistry: StatusListRegistryConfig,
     issueBgJobRecordsLimit: Int,
     issueBgJobRecurrenceDelay: Duration,

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/jobs/IssueBackgroundJobs.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/jobs/IssueBackgroundJobs.scala
@@ -495,7 +495,7 @@ object IssueBackgroundJobs extends BackgroundJobsHelper {
               credentialService <- ZIO.service[CredentialService]
               config <- ZIO.service[AppConfig]
               _ <- credentialService
-                .generateSDJWTCredential(id)
+                .generateSDJWTCredential(id, config.pollux.credentialSdJwtExpirationTime)
                 .provideSomeLayer(ZLayer.succeed(walletAccessContext))
             } yield ()).mapError(e => (walletAccessContext, e))
           } yield result

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/CredentialService.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/CredentialService.scala
@@ -4,17 +4,12 @@ import io.circe.{Json, JsonObject}
 import io.circe.syntax.*
 import org.hyperledger.identus.castor.core.model.did.CanonicalPrismDID
 import org.hyperledger.identus.mercury.model.DidId
-import org.hyperledger.identus.mercury.protocol.issuecredential.{
-  Attribute,
-  IssueCredential,
-  OfferCredential,
-  RequestCredential
-}
+import org.hyperledger.identus.mercury.protocol.issuecredential.{Attribute, IssueCredential, OfferCredential, RequestCredential}
 import org.hyperledger.identus.pollux.core.model.*
 import org.hyperledger.identus.pollux.core.model.error.CredentialServiceError
 import org.hyperledger.identus.pollux.core.model.error.CredentialServiceError.*
 import org.hyperledger.identus.shared.models.WalletAccessContext
-import zio.{IO, ZIO}
+import zio.{Duration, IO, ZIO}
 
 import java.nio.charset.StandardCharsets
 import java.util.UUID
@@ -118,6 +113,7 @@ trait CredentialService {
 
   def generateSDJWTCredential(
       recordId: DidCommID,
+      expirationTime: Duration,
   ): ZIO[WalletAccessContext, CredentialServiceError, IssueCredentialRecord]
 
   def generateAnonCredsCredential(

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/CredentialService.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/CredentialService.scala
@@ -4,7 +4,12 @@ import io.circe.{Json, JsonObject}
 import io.circe.syntax.*
 import org.hyperledger.identus.castor.core.model.did.CanonicalPrismDID
 import org.hyperledger.identus.mercury.model.DidId
-import org.hyperledger.identus.mercury.protocol.issuecredential.{Attribute, IssueCredential, OfferCredential, RequestCredential}
+import org.hyperledger.identus.mercury.protocol.issuecredential.{
+  Attribute,
+  IssueCredential,
+  OfferCredential,
+  RequestCredential
+}
 import org.hyperledger.identus.pollux.core.model.*
 import org.hyperledger.identus.pollux.core.model.error.CredentialServiceError
 import org.hyperledger.identus.pollux.core.model.error.CredentialServiceError.*

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/CredentialServiceNotifier.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/CredentialServiceNotifier.scala
@@ -8,6 +8,7 @@ import org.hyperledger.identus.mercury.protocol.issuecredential.{IssueCredential
 import org.hyperledger.identus.pollux.core.model.{DidCommID, IssueCredentialRecord}
 import org.hyperledger.identus.pollux.core.model.error.CredentialServiceError
 import org.hyperledger.identus.shared.models.WalletAccessContext
+import zio.{Duration, IO, URLayer, ZIO, ZLayer}
 import zio.{IO, URLayer, ZIO, ZLayer}
 
 import java.util.UUID
@@ -151,9 +152,10 @@ class CredentialServiceNotifier(
     notifyOnSuccess(svc.generateJWTCredential(recordId, statusListRegistryUrl))
 
   override def generateSDJWTCredential(
-      recordId: DidCommID
+      recordId: DidCommID,
+      expirationTime: Duration,
   ): ZIO[WalletAccessContext, CredentialServiceError, IssueCredentialRecord] =
-    notifyOnSuccess(svc.generateSDJWTCredential(recordId))
+    notifyOnSuccess(svc.generateSDJWTCredential(recordId, expirationTime))
 
   override def generateAnonCredsCredential(
       recordId: DidCommID

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/MockCredentialService.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/MockCredentialService.scala
@@ -7,9 +7,9 @@ import org.hyperledger.identus.mercury.protocol.issuecredential.{IssueCredential
 import org.hyperledger.identus.pollux.core.model.{DidCommID, IssueCredentialRecord}
 import org.hyperledger.identus.pollux.core.model.error.CredentialServiceError
 import org.hyperledger.identus.shared.models.WalletAccessContext
+import zio.{mock, Duration, IO, URLayer, ZIO, ZLayer}
 import zio.{mock, IO, URLayer, ZIO, ZLayer}
 import zio.mock.{Mock, Proxy}
-import zio.{Duration, IO, URLayer, ZIO, ZLayer, mock}
 
 import java.util.UUID
 

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/MockCredentialService.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/MockCredentialService.scala
@@ -9,6 +9,7 @@ import org.hyperledger.identus.pollux.core.model.error.CredentialServiceError
 import org.hyperledger.identus.shared.models.WalletAccessContext
 import zio.{mock, IO, URLayer, ZIO, ZLayer}
 import zio.mock.{Mock, Proxy}
+import zio.{Duration, IO, URLayer, ZIO, ZLayer, mock}
 
 import java.util.UUID
 
@@ -70,7 +71,7 @@ object MockCredentialService extends Mock[CredentialService] {
   object ReceiveCredentialRequest extends Effect[RequestCredential, CredentialServiceError, IssueCredentialRecord]
   object AcceptCredentialRequest extends Effect[DidCommID, CredentialServiceError, IssueCredentialRecord]
   object GenerateJWTCredential extends Effect[(DidCommID, String), CredentialServiceError, IssueCredentialRecord]
-  object GenerateSDJWTCredential extends Effect[DidCommID, CredentialServiceError, IssueCredentialRecord]
+  object GenerateSDJWTCredential extends Effect[(DidCommID, Duration), CredentialServiceError, IssueCredentialRecord]
   object GenerateAnonCredsCredential extends Effect[DidCommID, CredentialServiceError, IssueCredentialRecord]
   object ReceiveCredentialIssue extends Effect[IssueCredential, CredentialServiceError, IssueCredentialRecord]
   object MarkOfferSent extends Effect[DidCommID, CredentialServiceError, IssueCredentialRecord]
@@ -191,9 +192,10 @@ object MockCredentialService extends Mock[CredentialService] {
         proxy(GenerateJWTCredential, recordId, statusListRegistryUrl)
 
       override def generateSDJWTCredential(
-          recordId: DidCommID
+          recordId: DidCommID,
+          expirationTime: Duration,
       ): ZIO[WalletAccessContext, CredentialServiceError, IssueCredentialRecord] =
-        proxy(GenerateSDJWTCredential, recordId)
+        proxy(GenerateSDJWTCredential, recordId, expirationTime)
 
       override def generateAnonCredsCredential(
           recordId: DidCommID

--- a/pollux/vc-jwt/src/main/scala/org/hyperledger/identus/pollux/vc/jwt/DidJWT.scala
+++ b/pollux/vc-jwt/src/main/scala/org/hyperledger/identus/pollux/vc/jwt/DidJWT.scala
@@ -56,11 +56,7 @@ class ES256KSigner(privateKey: PrivateKey) extends Signer {
 
 class EdSigner(ed25519KeyPair: Ed25519KeyPair) extends Signer {
   lazy val signer: Ed25519Signer = {
-    val d = java.util.Base64.getUrlEncoder.withoutPadding().encodeToString(ed25519KeyPair.privateKey.getEncoded)
-    val x = java.util.Base64.getUrlEncoder.withoutPadding().encodeToString(ed25519KeyPair.publicKey.getEncoded)
-    val okpJson = s"""{"kty":"OKP","crv":"Ed25519","d":"$d","x":"$x"}"""
-    val octetKeyPair = OctetKeyPair.parse(okpJson)
-    val ed25519Signer = Ed25519Signer(octetKeyPair)
+    val ed25519Signer = Ed25519Signer(ed25519KeyPair.toOctetKeyPair)
     ed25519Signer
   }
 


### PR DESCRIPTION
### Description: 
This PR allows the expiration time for the Agent (Role Issuer) to be configurable.
The expiration time for SD JWT credentials can also be set when the Issuer makes a credential offer, including other claims in the exp field.
If the exp field is present, its value takes precedence over the configurable value.
The value in the exp field must be specified in Unix epoch seconds.
For more details, refer to [RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519#page-9).

 "claims": {
       ......
        "exp" : 1618244393 
    }


### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
