### PR TITLE
feat: authentication for oid4vci credential and nonce endpoint

### DIFF
--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/MainApp.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/MainApp.scala
@@ -27,8 +27,8 @@ import org.hyperledger.identus.credential.status.controller.CredentialStatusCont
 import org.hyperledger.identus.didcomm.controller.DIDCommControllerImpl
 import org.hyperledger.identus.event.controller.EventControllerImpl
 import org.hyperledger.identus.event.notification.EventNotificationServiceImpl
+import org.hyperledger.identus.iam.authentication.{DefaultAuthenticator, Oid4vciAuthenticatorFactory}
 import org.hyperledger.identus.iam.authentication.apikey.JdbcAuthenticationRepository
-import org.hyperledger.identus.iam.authentication.DefaultAuthenticator
 import org.hyperledger.identus.iam.authorization.core.EntityPermissionManagementService
 import org.hyperledger.identus.iam.authorization.DefaultPermissionManagementService
 import org.hyperledger.identus.iam.entity.http.controller.{EntityController, EntityControllerImpl}
@@ -195,6 +195,7 @@ object MainApp extends ZIOAppDefault {
           DefaultAuthenticator.layer,
           DefaultPermissionManagementService.layer,
           EntityPermissionManagementService.layer,
+          Oid4vciAuthenticatorFactory.layer,
           // grpc
           GrpcModule.prismNodeStubLayer,
           // storage

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/iam/authentication/Authenticator.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/iam/authentication/Authenticator.scala
@@ -51,8 +51,8 @@ trait Authorizer[E <: BaseEntity] {
       .mapError(msg =>
         AuthenticationError.UnexpectedError(s"Unable to retrieve entity role for entity id ${entity.id}. $msg")
       )
-      .filterOrFail(_ != EntityRole.Admin)(
-        AuthenticationError.InvalidRole("Admin role is not allowed to access the tenant's wallet.")
+      .filterOrFail(_ == EntityRole.Tenant)(
+        AuthenticationError.InvalidRole("Only Tenant role is allowed to access the tenant's wallet.")
       )
       .flatMap(_ => authorizeWalletAccessLogic(entity))
 

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/iam/authentication/Oid4vciAuthenticator.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/iam/authentication/Oid4vciAuthenticator.scala
@@ -1,0 +1,90 @@
+package org.hyperledger.identus.iam.authentication
+
+import org.hyperledger.identus.agent.walletapi.model.{BaseEntity, EntityRole}
+import org.hyperledger.identus.iam.authentication.oidc.{
+  AccessToken,
+  JwtAuthenticationError,
+  JwtCredentials,
+  Oauth2TokenIntrospector,
+  RemoteOauth2TokenIntrospector
+}
+import org.hyperledger.identus.oid4vci.service.OIDCCredentialIssuerService
+import org.hyperledger.identus.pollux.core.service.OID4VCIIssuerMetadataService
+import zio.*
+import zio.http.Client
+
+import java.util.UUID
+
+final case class ExternalEntity(id: UUID) extends BaseEntity {
+  override def role: Either[String, EntityRole] = Right(EntityRole.ExternalParty)
+}
+
+case class Oid4vciAuthenticator(tokenIntrospector: Oauth2TokenIntrospector) extends Authenticator[ExternalEntity] {
+
+  override def isEnabled: Boolean = true
+
+  def authenticate(credentials: Credentials): IO[AuthenticationError, ExternalEntity] = {
+    credentials match {
+      case JwtCredentials(Some(token)) if token.nonEmpty => authenticate(token)
+      case JwtCredentials(Some(_))                       => ZIO.fail(JwtAuthenticationError.emptyToken)
+      case JwtCredentials(None) => ZIO.fail(AuthenticationError.InvalidCredentials("Bearer token is not provided"))
+      case other                => ZIO.fail(AuthenticationError.InvalidCredentials("Bearer token is not provided"))
+    }
+  }
+
+  private def authenticate(token: String): IO[AuthenticationError, ExternalEntity] = {
+    for {
+      accessToken <- ZIO
+        .fromEither(AccessToken.fromString(token))
+        .mapError(AuthenticationError.InvalidCredentials.apply)
+      introspection <- tokenIntrospector
+        .introspectToken(accessToken)
+        .mapError(e => AuthenticationError.UnexpectedError(e.getMessage))
+      _ <- ZIO
+        .fail(AuthenticationError.InvalidCredentials("The accessToken is invalid."))
+        .unless(introspection.active)
+      entityId <- ZIO
+        .fromOption(introspection.sub)
+        .mapError(_ => AuthenticationError.UnexpectedError("Subject ID is not found in the accessToken."))
+        .flatMap { id =>
+          ZIO
+            .attempt(UUID.fromString(id))
+            .mapError(e => AuthenticationError.UnexpectedError(s"Subject ID in accessToken is not a UUID. $e"))
+        }
+    } yield ExternalEntity(entityId)
+  }
+}
+
+class Oid4vciAuthenticatorFactory(
+    httpClient: Client,
+    issuerService: OIDCCredentialIssuerService,
+    metadataService: OID4VCIIssuerMetadataService
+) {
+  def make(issuerState: String): IO[AuthenticationError, Oid4vciAuthenticator] =
+    issuerService
+      .getIssuanceSessionByIssuerState(issuerState)
+      .mapError(e =>
+        AuthenticationError.UnexpectedError(s"Unable to get issuanceSession from issuerState: $issuerState")
+      )
+      .flatMap(session => make(session.issuerId))
+
+  def make(issuerId: UUID): IO[AuthenticationError, Oid4vciAuthenticator] =
+    for {
+      issuer <- metadataService
+        .getCredentialIssuer(issuerId)
+        .mapError(e => AuthenticationError.UnexpectedError(s"Unable to get issuer from issuerId: $issuerId"))
+      tokenIntrospector <- RemoteOauth2TokenIntrospector
+        .fromAuthorizationServer(
+          httpClient,
+          issuer.authorizationServer,
+          issuer.authorizationServerClientId,
+          issuer.authorizationServerClientSecret
+        )
+        .mapError(e => AuthenticationError.UnexpectedError(s"Unable to create token introspector: $e"))
+    } yield Oid4vciAuthenticator(tokenIntrospector)
+}
+
+object Oid4vciAuthenticatorFactory {
+  def layer: URLayer[Client & OIDCCredentialIssuerService & OID4VCIIssuerMetadataService, Oid4vciAuthenticatorFactory] =
+    ZLayer.fromFunction(Oid4vciAuthenticatorFactory(_, _, _))
+}

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/iam/authentication/oidc/KeycloakAuthenticator.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/iam/authentication/oidc/KeycloakAuthenticator.scala
@@ -60,7 +60,7 @@ final class AccessToken private (token: String, claims: JwtClaim, rolesClaimPath
 }
 
 object AccessToken {
-  def fromString(token: String, rolesClaimPath: Seq[String]): Either[String, AccessToken] =
+  def fromString(token: String, rolesClaimPath: Seq[String] = Nil): Either[String, AccessToken] =
     JwtCirce
       .decode(token, JwtOptions(false, false, false))
       .map(claims => AccessToken(token, claims, rolesClaimPath))

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/iam/authentication/oidc/KeycloakAuthenticatorImpl.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/iam/authentication/oidc/KeycloakAuthenticatorImpl.scala
@@ -81,6 +81,8 @@ class KeycloakAuthenticatorImpl(
       ctx <- role match {
         case EntityRole.Admin  => ZIO.succeed(WalletAdministrationContext.Admin())
         case EntityRole.Tenant => selfServiceCtx
+        case EntityRole.ExternalParty =>
+          ZIO.fail(AuthenticationError.InvalidRole("External party cannot access the wallet."))
       }
     } yield ctx
   }

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/iam/authentication/oidc/Oauth2TokenIntrospector.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/iam/authentication/oidc/Oauth2TokenIntrospector.scala
@@ -1,0 +1,95 @@
+package org.hyperledger.identus.iam.authentication.oidc
+
+import zio.*
+import zio.http.*
+import zio.json.*
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+final case class AuthorizationServerMetadata(introspection_endpoint: String)
+
+object AuthorizationServerMetadata {
+  given JsonEncoder[AuthorizationServerMetadata] = JsonEncoder.derived
+  given JsonDecoder[AuthorizationServerMetadata] = JsonDecoder.derived
+}
+
+final case class TokenIntrospection(active: Boolean, sub: Option[String])
+
+object TokenIntrospection {
+  given JsonEncoder[TokenIntrospection] = JsonEncoder.derived
+  given JsonDecoder[TokenIntrospection] = JsonDecoder.derived
+}
+
+trait Oauth2TokenIntrospector {
+  def introspectToken(token: AccessToken): IO[Throwable, TokenIntrospection]
+}
+
+// TODO: support offline introspection
+class RemoteOauth2TokenIntrospector(
+    introspectionUrl: String,
+    httpClient: Client,
+    clientId: String,
+    clientSecret: String
+) extends Oauth2TokenIntrospector {
+
+  private val baseFormHeaders = Headers(Header.ContentType(MediaType.application.`x-www-form-urlencoded`))
+
+  // https://www.keycloak.org/docs/22.0.4/securing_apps/#_token_introspection_endpoint
+  override def introspectToken(token: AccessToken): Task[TokenIntrospection] = {
+    (for {
+      url <- ZIO.fromEither(URL.decode(introspectionUrl)).orDie
+      response <- httpClient
+        .request(
+          Request(
+            url = url,
+            method = Method.POST,
+            headers = baseFormHeaders ++ Headers(
+              Header.Authorization.Basic(
+                username = URLEncoder.encode(clientId, StandardCharsets.UTF_8),
+                password = URLEncoder.encode(clientSecret, StandardCharsets.UTF_8)
+              )
+            ),
+            body = Body.fromURLEncodedForm(
+              Form(
+                FormField.simpleField("token", token.toString)
+              )
+            )
+          )
+        )
+        .logError("Fail to introspect token on keycloak.")
+      body <- response.body.asString
+        .logError("Fail parse keycloak introspection response.")
+      result <-
+        if (response.status.code == 200) {
+          ZIO
+            .fromEither(body.fromJson[TokenIntrospection])
+            .logError("Fail to decode keycloak token introspection response")
+            .mapError(RuntimeException(_))
+        } else {
+          ZIO.logError(s"Keycloak token introspection was unsucessful. Status: ${response.status}. Response: $body") *>
+            ZIO.fail(RuntimeException("Token introspection did not return a successful result."))
+        }
+    } yield result).provide(Scope.default)
+  }
+
+}
+
+object RemoteOauth2TokenIntrospector {
+  def fromAuthorizationServer(
+      httpClient: Client,
+      authorizationServer: java.net.URL,
+      clientId: String,
+      clientSecret: String
+  ): Task[RemoteOauth2TokenIntrospector] = {
+    for {
+      url <- ZIO.fromEither(URL.decode(authorizationServer.toString())).orDie
+      metadataUrl = url / ".well-known" / "openid-configuration"
+      response <- httpClient.request(Request(url = metadataUrl, method = Method.GET))
+      body <- response.body.asString
+      metadata <- ZIO
+        .fromEither(body.fromJson[AuthorizationServerMetadata])
+        .mapError(e => RuntimeException(s"Unable to parse authorization server metadata: $e"))
+    } yield RemoteOauth2TokenIntrospector(metadata.introspection_endpoint, httpClient, clientId, clientSecret)
+  }.provide(Scope.default)
+}

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/CredentialIssuerServerEndpoints.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/CredentialIssuerServerEndpoints.scala
@@ -2,31 +2,42 @@ package org.hyperledger.identus.oid4vci
 
 import org.hyperledger.identus.agent.walletapi.model.BaseEntity
 import org.hyperledger.identus.api.http.ErrorResponse
-import org.hyperledger.identus.iam.authentication.{Authenticator, Authorizer, DefaultAuthenticator, SecurityLogic}
+import org.hyperledger.identus.iam.authentication.{
+  AuthenticationError,
+  Authenticator,
+  Authorizer,
+  DefaultAuthenticator,
+  Oid4vciAuthenticatorFactory,
+  SecurityLogic
+}
 import org.hyperledger.identus.oid4vci.controller.CredentialIssuerController
-import org.hyperledger.identus.oid4vci.http.{CredentialErrorResponse, NonceResponse}
+import org.hyperledger.identus.oid4vci.http.{CredentialErrorResponse, ExtendedErrorResponse, NonceResponse}
 import org.hyperledger.identus.LogUtils.*
 import sttp.tapir.ztapir.*
 import zio.*
+
+import scala.language.implicitConversions
 
 case class CredentialIssuerServerEndpoints(
     credentialIssuerController: CredentialIssuerController,
     authenticator: Authenticator[BaseEntity],
     authorizer: Authorizer[BaseEntity],
+    oid4vciAuthenticatorFactory: Oid4vciAuthenticatorFactory
 ) {
   val credentialServerEndpoint: ZServerEndpoint[Any, Any] =
     CredentialIssuerEndpoints.credentialEndpoint
-      .zServerSecurityLogic(
-        SecurityLogic // TODO: add OIDC client authenticator
-          .authenticate(_)(authenticator)
-          .mapError(Left[ErrorResponse, CredentialErrorResponse])
-      )
-      .serverLogic { wac =>
+      .zServerSecurityLogic(ZIO.succeed)
+      .serverLogic { jwt =>
         { case (rc, issuerId, request) =>
-          ZIO.succeed(request).debug("credentialRequest") *>
-            credentialIssuerController
-              .issueCredential(rc, issuerId, request)
-              .logTrace(rc)
+          oid4vciAuthenticatorFactory
+            .make(issuerId)
+            .flatMap(_.authenticate(jwt))
+            .mapError[CredentialErrorResponse](identity)
+            .flatMap { entity => // FIXME: this entity should be checked
+              credentialIssuerController
+                .issueCredential(rc, issuerId, request)
+                .logTrace(rc)
+            }
         }
       }
 
@@ -44,16 +55,18 @@ case class CredentialIssuerServerEndpoints(
 
   val nonceServerEndpoint: ZServerEndpoint[Any, Any] =
     CredentialIssuerEndpoints.nonceEndpoint
-      .zServerSecurityLogic(
-        // FIXME: how can authorization server authorize itself?
-        SecurityLogic.authorizeWalletAccessWith(_)(authenticator, authorizer)
-      )
-      .serverLogic { wac =>
-        { case (rc, id, request) =>
-          credentialIssuerController
-            .getNonce(rc, id, request)
-            .provideSomeLayer(ZLayer.succeed(wac))
-            .logTrace(rc)
+      .zServerSecurityLogic(ZIO.succeed)
+      .serverLogic { jwt =>
+        { case (rc, request) =>
+          oid4vciAuthenticatorFactory
+            .make(request.issuerState)
+            .flatMap(_.authenticate(jwt))
+            .mapError(AuthenticationError.toErrorResponse)
+            .flatMap { entity =>
+              credentialIssuerController
+                .getNonce(rc, request)
+                .logTrace(rc)
+            }
         }
       }
 
@@ -162,11 +175,20 @@ case class CredentialIssuerServerEndpoints(
 }
 
 object CredentialIssuerServerEndpoints {
-  def all: URIO[DefaultAuthenticator & CredentialIssuerController, List[ZServerEndpoint[Any, Any]]] = {
+  def all: URIO[
+    DefaultAuthenticator & Oid4vciAuthenticatorFactory & CredentialIssuerController,
+    List[ZServerEndpoint[Any, Any]]
+  ] = {
     for {
       authenticator <- ZIO.service[DefaultAuthenticator]
       credentialIssuerController <- ZIO.service[CredentialIssuerController]
-      oidcEndpoints = CredentialIssuerServerEndpoints(credentialIssuerController, authenticator, authenticator)
+      oid4vciAuthenticatorFactory <- ZIO.service[Oid4vciAuthenticatorFactory]
+      oidcEndpoints = CredentialIssuerServerEndpoints(
+        credentialIssuerController,
+        authenticator,
+        authenticator,
+        oid4vciAuthenticatorFactory
+      )
     } yield oidcEndpoints.all
   }
 }

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/controller/CredentialIssuerController.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/controller/CredentialIssuerController.scala
@@ -8,7 +8,7 @@ import org.hyperledger.identus.castor.core.model.did.PrismDID
 import org.hyperledger.identus.oid4vci.http.*
 import org.hyperledger.identus.oid4vci.http.CredentialErrorCode.*
 import org.hyperledger.identus.oid4vci.service.OIDCCredentialIssuerService
-import org.hyperledger.identus.oid4vci.CredentialIssuerEndpoints.ExtendedErrorResponse
+import org.hyperledger.identus.pollux.core.model.oid4vci.CredentialIssuer as PolluxCredentialIssuer
 import org.hyperledger.identus.pollux.core.service.OID4VCIIssuerMetadataService
 import org.hyperledger.identus.shared.models.WalletAccessContext
 import zio.{IO, URLayer, ZIO, ZLayer}
@@ -32,9 +32,8 @@ trait CredentialIssuerController {
 
   def getNonce(
       ctx: RequestContext,
-      issuerId: UUID,
       request: NonceRequest
-  ): ZIO[WalletAccessContext, ErrorResponse, NonceResponse]
+  ): IO[ErrorResponse, NonceResponse]
 
   def createCredentialIssuer(
       ctx: RequestContext,
@@ -83,44 +82,34 @@ trait CredentialIssuerController {
 object CredentialIssuerController {
   object Errors {
     def badRequestInvalidDID(didRef: String, details: String): ExtendedErrorResponse =
-      Right(
-        CredentialErrorResponse(
-          error = invalid_request,
-          errorDescription = Some(s"Invalid DID input: $didRef. Error: $details")
-        )
+      CredentialErrorResponse(
+        error = invalid_request,
+        errorDescription = Some(s"Invalid DID input: $didRef. Error: $details")
       )
 
     def badRequestDIDResolutionFailed(didRef: String, details: String): ExtendedErrorResponse =
-      Right(
-        CredentialErrorResponse(
-          error = invalid_request,
-          errorDescription = Some(s"Failed to resolve DID: $didRef. Error: $details")
-        )
+      CredentialErrorResponse(
+        error = invalid_request,
+        errorDescription = Some(s"Failed to resolve DID: $didRef. Error: $details")
       )
 
     def badRequestInvalidProof(jwt: String, details: String): ExtendedErrorResponse =
-      Right(
-        CredentialErrorResponse(error = invalid_proof, errorDescription = Some(s"Invalid proof: $jwt. Error: $details"))
-      )
+      CredentialErrorResponse(error = invalid_proof, errorDescription = Some(s"Invalid proof: $jwt. Error: $details"))
 
     def badRequestUnsupportedCredentialFormat(format: CredentialFormat): ExtendedErrorResponse =
-      Right(
-        CredentialErrorResponse(
-          error = unsupported_credential_format,
-          errorDescription = Some(s"Unsupported credential format: $format")
-        )
+      CredentialErrorResponse(
+        error = unsupported_credential_format,
+        errorDescription = Some(s"Unsupported credential format: $format")
       )
 
     def badRequestUnsupportedCredentialType(details: String): ExtendedErrorResponse =
-      Right(
-        CredentialErrorResponse(
-          error = unsupported_credential_type,
-          errorDescription = Some(s"Unsupported credential type. Error: $details")
-        )
+      CredentialErrorResponse(
+        error = unsupported_credential_type,
+        errorDescription = Some(s"Unsupported credential type. Error: $details")
       )
 
     def serverError(details: Option[String]): ExtendedErrorResponse =
-      Left(internalServerError("InternalServerError", details))
+      internalServerError("InternalServerError", details)
   }
 }
 
@@ -227,12 +216,11 @@ case class CredentialIssuerControllerImpl(
 
   override def getNonce(
       ctx: RequestContext,
-      issuerId: UUID,
       request: NonceRequest
-  ): ZIO[WalletAccessContext, ErrorResponse, NonceResponse] = {
+  ): IO[ErrorResponse, NonceResponse] = {
     credentialIssuerService
-      .getIssuanceSessionNonce(request.issuerState)
-      .map(nonce => NonceResponse(nonce))
+      .getIssuanceSessionByIssuerState(request.issuerState)
+      .map(session => NonceResponse(session.nonce))
       .mapError(ue =>
         internalServerError(detail = Some(s"Unexpected error while creating credential offer: ${ue.message}"))
       )
@@ -243,8 +231,15 @@ case class CredentialIssuerControllerImpl(
       request: CreateCredentialIssuerRequest
   ): ZIO[WalletAccessContext, ErrorResponse, CredentialIssuer] =
     for {
-      authServerUrl <- parseURL(request.authorizationServer)
-      issuer <- issuerMetadataService.createCredentialIssuer(authServerUrl)
+      authServerUrl <- parseURL(request.authorizationServer.url)
+      id = request.id.getOrElse(UUID.randomUUID())
+      issuerToCreate = PolluxCredentialIssuer(
+        id,
+        authServerUrl,
+        request.authorizationServer.clientId,
+        request.authorizationServer.clientSecret
+      )
+      issuer <- issuerMetadataService.createCredentialIssuer(issuerToCreate)
     } yield issuer
 
   override def getCredentialIssuers(

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/domain/IssuanceSession.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/domain/IssuanceSession.scala
@@ -6,6 +6,7 @@ import java.util.UUID
 
 case class IssuanceSession(
     id: UUID,
+    issuerId: UUID,
     nonce: String,
     issuerState: String,
     schemaId: Option[String],

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/http/CredentialIssuer.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/http/CredentialIssuer.scala
@@ -6,12 +6,23 @@ import zio.json.{DeriveJsonDecoder, DeriveJsonEncoder, JsonDecoder, JsonEncoder}
 
 import java.util.UUID
 
-case class CreateCredentialIssuerRequest(authorizationServer: String)
+case class CreateCredentialIssuerRequest(
+    id: Option[UUID],
+    authorizationServer: AuthorizationServer,
+)
 
 object CreateCredentialIssuerRequest {
   given schema: Schema[CreateCredentialIssuerRequest] = Schema.derived
   given encoder: JsonEncoder[CreateCredentialIssuerRequest] = DeriveJsonEncoder.gen
   given decoder: JsonDecoder[CreateCredentialIssuerRequest] = DeriveJsonDecoder.gen
+}
+
+case class AuthorizationServer(url: String, clientId: String, clientSecret: String)
+
+object AuthorizationServer {
+  given schema: Schema[AuthorizationServer] = Schema.derived
+  given encoder: JsonEncoder[AuthorizationServer] = DeriveJsonEncoder.gen
+  given decoder: JsonDecoder[AuthorizationServer] = DeriveJsonDecoder.gen
 }
 
 case class CredentialIssuer(id: UUID, authorizationServer: String)

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/http/CredentialRequest.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/http/CredentialRequest.scala
@@ -181,6 +181,7 @@ object LdpProof {
 enum CredentialFormat {
   case jwt_vc_json
   case anoncreds
+  case `vc+sd-jwt`
 }
 
 object CredentialFormat {
@@ -193,11 +194,13 @@ object CredentialFormat {
   given Conversion[PolluxCredentialFormat, CredentialFormat] = {
     case PolluxCredentialFormat.JWT       => CredentialFormat.jwt_vc_json
     case PolluxCredentialFormat.AnonCreds => CredentialFormat.anoncreds
+    case PolluxCredentialFormat.SDJWT     => CredentialFormat.`vc+sd-jwt`
   }
 
   given Conversion[CredentialFormat, PolluxCredentialFormat] = {
     case CredentialFormat.jwt_vc_json => PolluxCredentialFormat.JWT
     case CredentialFormat.anoncreds   => PolluxCredentialFormat.AnonCreds
+    case CredentialFormat.`vc+sd-jwt` => PolluxCredentialFormat.SDJWT
   }
 }
 

--- a/cloud-agent/service/server/src/test/scala/org/hyperledger/identus/api/util/Tapir2StaticOAS.scala
+++ b/cloud-agent/service/server/src/test/scala/org/hyperledger/identus/api/util/Tapir2StaticOAS.scala
@@ -6,7 +6,7 @@ import org.hyperledger.identus.castor.controller.{DIDController, DIDRegistrarCon
 import org.hyperledger.identus.connect.controller.ConnectionController
 import org.hyperledger.identus.credential.status.controller.CredentialStatusController
 import org.hyperledger.identus.event.controller.EventController
-import org.hyperledger.identus.iam.authentication.DefaultAuthenticator
+import org.hyperledger.identus.iam.authentication.{DefaultAuthenticator, Oid4vciAuthenticatorFactory}
 import org.hyperledger.identus.iam.entity.http.controller.EntityController
 import org.hyperledger.identus.iam.wallet.http.controller.WalletManagementController
 import org.hyperledger.identus.issue.controller.IssueController
@@ -57,7 +57,8 @@ object Tapir2StaticOAS extends ZIOAppDefault {
         ZLayer.succeed(mock[WalletManagementController]) ++
         ZLayer.succeed(mock[DefaultAuthenticator]) ++
         ZLayer.succeed(mock[EventController]) ++
-        ZLayer.succeed(mock[CredentialIssuerController])
+        ZLayer.succeed(mock[CredentialIssuerController]) ++
+        ZLayer.succeed(mock[Oid4vciAuthenticatorFactory])
     )
   }
 

--- a/cloud-agent/service/wallet-api/src/main/scala/org/hyperledger/identus/agent/walletapi/model/Entity.scala
+++ b/cloud-agent/service/wallet-api/src/main/scala/org/hyperledger/identus/agent/walletapi/model/Entity.scala
@@ -10,6 +10,7 @@ import java.util.UUID
 enum EntityRole {
   case Admin extends EntityRole
   case Tenant extends EntityRole
+  case ExternalParty extends EntityRole
 }
 
 trait BaseEntity {

--- a/examples/.nickel/stack.ncl
+++ b/examples/.nickel/stack.ncl
@@ -68,6 +68,8 @@ in
                   HURL_alice_username = "alice",
                   HURL_alice_password = "1234",
                   HURL_alice_wallet_client_id = "alice-wallet",
+                  HURL_agent_client_id = "cloud-agent",
+                  HURL_agent_client_secret = "secret",
                 }
               },
         }
@@ -115,7 +117,6 @@ in
         }
       in
       {
-        version = "3",
         configs = _caddy.makeCaddyConfig caddyArgs,
         volumes = {
           pg_data_node = {},

--- a/examples/mt-keycloak-vault/compose.yaml
+++ b/examples/mt-keycloak-vault/compose.yaml
@@ -162,7 +162,6 @@ services:
     image: hashicorp/vault:1.15.6
     ports:
     - 8200:8200
-version: '3'
 volumes:
   pg_data_default: {}
   pg_data_node: {}

--- a/examples/mt-keycloak/compose.yaml
+++ b/examples/mt-keycloak/compose.yaml
@@ -143,7 +143,6 @@ services:
     - pg_data_node:/var/lib/postgresql/data
     - ../.shared/postgres/init-script.sh:/docker-entrypoint-initdb.d/init-script.sh
     - ../.shared/postgres/max_conns.sql:/docker-entrypoint-initdb.d/max_conns.sql
-version: '3'
 volumes:
   pg_data_default: {}
   pg_data_node: {}

--- a/examples/mt/compose.yaml
+++ b/examples/mt/compose.yaml
@@ -109,7 +109,6 @@ services:
     - pg_data_node:/var/lib/postgresql/data
     - ../.shared/postgres/init-script.sh:/docker-entrypoint-initdb.d/init-script.sh
     - ../.shared/postgres/max_conns.sql:/docker-entrypoint-initdb.d/max_conns.sql
-version: '3'
 volumes:
   pg_data_default: {}
   pg_data_node: {}

--- a/examples/st-multi/compose.yaml
+++ b/examples/st-multi/compose.yaml
@@ -261,7 +261,6 @@ services:
     - pg_data_node:/var/lib/postgresql/data
     - ../.shared/postgres/init-script.sh:/docker-entrypoint-initdb.d/init-script.sh
     - ../.shared/postgres/max_conns.sql:/docker-entrypoint-initdb.d/max_conns.sql
-version: '3'
 volumes:
   pg_data_holder: {}
   pg_data_issuer: {}

--- a/examples/st-oid4vci/bootstrap/01_init_realm.hurl
+++ b/examples/st-oid4vci/bootstrap/01_init_realm.hurl
@@ -26,6 +26,17 @@ authorization: Bearer {{ admin_access_token }}
 }
 HTTP 201
 
+# Create agent client
+POST {{ keycloak_base_url }}/admin/realms/{{ keycloak_realm }}/clients
+Authorization: Bearer {{ admin_access_token }}
+{
+  "id": "{{ agent_client_id }}",
+  "authorizationServicesEnabled": true,
+  "serviceAccountsEnabled": true,
+  "secret": "{{ agent_client_secret }}"
+}
+HTTP 201
+
 # Create Alice
 POST {{ keycloak_base_url }}/admin/realms/{{ keycloak_realm }}/users
 Authorization: Bearer {{ admin_access_token }}

--- a/examples/st-oid4vci/compose.yaml
+++ b/examples/st-oid4vci/compose.yaml
@@ -82,6 +82,8 @@ services:
     - /hurl/*.hurl
     - --test
     environment:
+      HURL_agent_client_id: cloud-agent
+      HURL_agent_client_secret: secret
       HURL_alice_password: '1234'
       HURL_alice_username: alice
       HURL_alice_wallet_client_id: alice-wallet
@@ -144,7 +146,6 @@ services:
     - pg_data_node:/var/lib/postgresql/data
     - ../.shared/postgres/init-script.sh:/docker-entrypoint-initdb.d/init-script.sh
     - ../.shared/postgres/max_conns.sql:/docker-entrypoint-initdb.d/max_conns.sql
-version: '3'
 volumes:
   pg_data_issuer: {}
   pg_data_node: {}

--- a/examples/st-oid4vci/demo.py
+++ b/examples/st-oid4vci/demo.py
@@ -95,7 +95,13 @@ def prepare_issuer():
     # prepare issuer
     credential_issuer = requests.post(
         f"{AGENT_URL}/oid4vci/issuers",
-        json={"authorizationServer": AUTHORIZATION_SERVER},
+        json={
+            "authorizationServer": {
+                "url": "http://external-keycloak-issuer:8080/realms/students",
+                "clientId": "cloud-agent",
+                "clientSecret": "secret",
+            }
+        },
     ).json()
     issuer_id = credential_issuer["id"]
     global CREDENTIAL_ISSUER
@@ -136,6 +142,9 @@ def holder_get_issuer_metadata(credential_issuer: str):
     response = requests.get(metadata_url).json()
     response["credential_endpoint"] = override_host(response["credential_endpoint"])
     response["credential_issuer"] = override_host(response["credential_issuer"])
+    response["authorization_servers"] = [
+        AUTHORIZATION_SERVER for s in response["authorization_servers"]
+    ]
     return response
 
 

--- a/examples/st-vault/compose.yaml
+++ b/examples/st-vault/compose.yaml
@@ -128,7 +128,6 @@ services:
     image: hashicorp/vault:1.15.6
     ports:
     - 8200:8200
-version: '3'
 volumes:
   pg_data_issuer: {}
   pg_data_node: {}

--- a/examples/st/compose.yaml
+++ b/examples/st/compose.yaml
@@ -109,7 +109,6 @@ services:
     - pg_data_node:/var/lib/postgresql/data
     - ../.shared/postgres/init-script.sh:/docker-entrypoint-initdb.d/init-script.sh
     - ../.shared/postgres/max_conns.sql:/docker-entrypoint-initdb.d/max_conns.sql
-version: '3'
 volumes:
   pg_data_issuer: {}
   pg_data_node: {}

--- a/extensions/keycloak-oid4vci/src/main/java/io/iohk/atala/keycloak/IdentusClient.java
+++ b/extensions/keycloak-oid4vci/src/main/java/io/iohk/atala/keycloak/IdentusClient.java
@@ -9,7 +9,6 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.jboss.logging.Logger;
 import org.keycloak.util.JsonSerialization;
-import org.yaml.snakeyaml.error.MissingEnvironmentVariableException;
 
 import java.io.IOException;
 import java.util.function.Supplier;
@@ -34,9 +33,10 @@ public class IdentusClient {
         return HttpClientBuilder.create().build();
     }
 
-    public NonceResponse syncTokenDetails(String issuerState) {
+    public NonceResponse getNonce(String token, String issuerState) {
         try (CloseableHttpClient client = httpClient.get()) {
-            HttpPost post = new HttpPost(identusUrl + "/oid4vci/issuers/08877304-a111-4fe4-a84c-8666610b1665/nonces"); // TODO: use real issuer URL
+            HttpPost post = new HttpPost(identusUrl + "/oid4vci/nonces");
+            post.setHeader("Authorization", "Bearer " + token);
             post.setEntity(new StringEntity(JsonSerialization.writeValueAsString(new NonceRequest(issuerState)), ContentType.APPLICATION_JSON));
             return NonceResponse.fromResponse(client.execute(post));
         } catch (IOException e) {

--- a/extensions/keycloak-oid4vci/src/main/java/io/iohk/atala/keycloak/OID4VCITokenEndpoint.java
+++ b/extensions/keycloak-oid4vci/src/main/java/io/iohk/atala/keycloak/OID4VCITokenEndpoint.java
@@ -34,12 +34,10 @@ public class OID4VCITokenEndpoint extends TokenEndpoint {
 
         if (code && issuerState != null) {
             Response originalResponse = super.createTokenResponse(user, userSession, clientSessionCtx, scopeParam, true, clientPolicyContextGenerator);
-
-            logger.warn("TokenEndpoint issuer_state: " + issuerState);
-            logger.warn("TokenEndpoint userSession ID: " + userSession.getId());
-
-            NonceResponse nonceResponse = identusClient.syncTokenDetails(issuerState);
             AccessTokenResponse responseEntity = (AccessTokenResponse) originalResponse.getEntity();
+
+            String token = responseEntity.getToken();
+            NonceResponse nonceResponse = identusClient.getNonce(token, issuerState);
             responseEntity.setOtherClaims(OID4VCIConstants.C_NONCE, nonceResponse.getNonce());
             responseEntity.setOtherClaims(OID4VCIConstants.C_NONCE_EXPIRE, nonceResponse.getNonceExpiresIn());
             return Response.fromResponse(originalResponse)

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/model/oid4vci/CredentialIssuer.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/model/oid4vci/CredentialIssuer.scala
@@ -5,7 +5,14 @@ import java.time.temporal.ChronoUnit
 import java.time.Instant
 import java.util.UUID
 
-case class CredentialIssuer(id: UUID, authorizationServer: URL, createdAt: Instant, updatedAt: Instant) {
+case class CredentialIssuer(
+    id: UUID,
+    authorizationServer: URL,
+    authorizationServerClientId: String,
+    authorizationServerClientSecret: String,
+    createdAt: Instant,
+    updatedAt: Instant
+) {
   def withTruncatedTimestamp(unit: ChronoUnit = ChronoUnit.MICROS): CredentialIssuer = copy(
     createdAt = createdAt.truncatedTo(unit),
     updatedAt = updatedAt.truncatedTo(unit),
@@ -13,8 +20,11 @@ case class CredentialIssuer(id: UUID, authorizationServer: URL, createdAt: Insta
 }
 
 object CredentialIssuer {
-  def apply(authorizationServer: URL): CredentialIssuer = {
+  def apply(authorizationServer: URL, clientId: String, clientSecret: String): CredentialIssuer =
+    apply(UUID.randomUUID(), authorizationServer, clientId, clientSecret)
+
+  def apply(id: UUID, authorizationServer: URL, clientId: String, clientSecret: String): CredentialIssuer = {
     val now = Instant.now
-    CredentialIssuer(UUID.randomUUID(), authorizationServer, now, now).withTruncatedTimestamp()
+    CredentialIssuer(id, authorizationServer, clientId, clientSecret, now, now).withTruncatedTimestamp()
   }
 }

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/OID4VCIIssuerMetadataService.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/OID4VCIIssuerMetadataService.scala
@@ -57,7 +57,7 @@ object OID4VCIIssuerMetadataServiceError {
 
 trait OID4VCIIssuerMetadataService {
   def getCredentialIssuer(issuerId: UUID): IO[IssuerIdNotFound, CredentialIssuer]
-  def createCredentialIssuer(authorizationServer: URL): URIO[WalletAccessContext, CredentialIssuer]
+  def createCredentialIssuer(issuer: CredentialIssuer): URIO[WalletAccessContext, CredentialIssuer]
   def getCredentialIssuers: URIO[WalletAccessContext, Seq[CredentialIssuer]]
   def updateCredentialIssuer(
       issuerId: UUID,
@@ -86,10 +86,8 @@ trait OID4VCIIssuerMetadataService {
 class OID4VCIIssuerMetadataServiceImpl(repository: OID4VCIIssuerMetadataRepository, uriDereferencer: URIDereferencer)
     extends OID4VCIIssuerMetadataService {
 
-  override def createCredentialIssuer(authorizationServer: URL): URIO[WalletAccessContext, CredentialIssuer] = {
-    val issuer = CredentialIssuer(authorizationServer)
+  override def createCredentialIssuer(issuer: CredentialIssuer): URIO[WalletAccessContext, CredentialIssuer] =
     repository.createIssuer(issuer).as(issuer)
-  }
 
   override def getCredentialIssuers: URIO[WalletAccessContext, Seq[CredentialIssuer]] =
     repository.findWalletIssuers

--- a/pollux/core/src/test/scala/org/hyperledger/identus/pollux/core/service/OID4VCIIssuerMetadataServiceSpecSuite.scala
+++ b/pollux/core/src/test/scala/org/hyperledger/identus/pollux/core/service/OID4VCIIssuerMetadataServiceSpecSuite.scala
@@ -1,5 +1,6 @@
 package org.hyperledger.identus.pollux.core.service
 
+import org.hyperledger.identus.pollux.core.model.oid4vci.CredentialIssuer
 import org.hyperledger.identus.pollux.core.model.CredentialFormat
 import org.hyperledger.identus.pollux.core.service.OID4VCIIssuerMetadataServiceError.{
   CredentialConfigurationNotFound,
@@ -11,9 +12,15 @@ import zio.{ZIO, ZLayer}
 import zio.test.*
 import zio.test.Assertion.*
 
-import java.net.URI
+import java.net.{URI, URL}
 
 object OID4VCIIssuerMetadataServiceSpecSuite {
+
+  private def makeCredentialIssuer(authorizationServer: URL): CredentialIssuer = CredentialIssuer(
+    authorizationServer = authorizationServer,
+    clientId = "client",
+    clientSecret = "secret"
+  )
 
   val testSuite = suite("OID4VCIssuerMetadataService")(
     test("get credential issuer successfully") {
@@ -21,8 +28,8 @@ object OID4VCIIssuerMetadataServiceSpecSuite {
         service <- ZIO.service[OID4VCIIssuerMetadataService]
         authServer1 = URI.create("http://example-1.com").toURL()
         authServer2 = URI.create("http://example-2.com").toURL()
-        issuer1 <- service.createCredentialIssuer(authServer1)
-        issuer2 <- service.createCredentialIssuer(authServer2)
+        issuer1 <- service.createCredentialIssuer(makeCredentialIssuer(authServer1))
+        issuer2 <- service.createCredentialIssuer(makeCredentialIssuer(authServer2))
         getIssuer1 <- service.getCredentialIssuer(issuer1.id)
         getIssuer2 <- service.getCredentialIssuer(issuer2.id)
         getIssuers <- service.getCredentialIssuers
@@ -43,7 +50,7 @@ object OID4VCIIssuerMetadataServiceSpecSuite {
       for {
         service <- ZIO.service[OID4VCIIssuerMetadataService]
         authServer = URI.create("http://example-1.com").toURL()
-        issuer <- service.createCredentialIssuer(authServer)
+        issuer <- service.createCredentialIssuer(makeCredentialIssuer(authServer))
         updatedAuthServer = URI.create("http://example-2.com").toURL()
         _ <- service.updateCredentialIssuer(issuer.id, authorizationServer = Some(updatedAuthServer))
         updatedIssuer <- service.getCredentialIssuer(issuer.id)
@@ -60,7 +67,7 @@ object OID4VCIIssuerMetadataServiceSpecSuite {
       for {
         service <- ZIO.service[OID4VCIIssuerMetadataService]
         authServer = URI.create("http://example-1.com").toURL()
-        issuer <- service.createCredentialIssuer(authServer)
+        issuer <- service.createCredentialIssuer(makeCredentialIssuer(authServer))
         _ <- service
           .createCredentialConfiguration(
             issuer.id,
@@ -77,7 +84,7 @@ object OID4VCIIssuerMetadataServiceSpecSuite {
       for {
         service <- ZIO.service[OID4VCIIssuerMetadataService]
         authServer = URI.create("http://example-1.com").toURL()
-        issuer <- service.createCredentialIssuer(authServer)
+        issuer <- service.createCredentialIssuer(makeCredentialIssuer(authServer))
         createCredConfig = (schemaId: String) =>
           service
             .createCredentialConfiguration(

--- a/pollux/sql-doobie/src/main/resources/sql/pollux/V21__add_issuer_metadata.sql
+++ b/pollux/sql-doobie/src/main/resources/sql/pollux/V21__add_issuer_metadata.sql
@@ -1,6 +1,8 @@
 CREATE TABLE public.issuer_metadata (
     id UUID PRIMARY KEY,
     authorization_server VARCHAR(500) NOT NULL,
+    authorization_server_client_id VARCHAR(100) NOT NULL,
+    authorization_server_client_secret VARCHAR(100) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL,
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
     wallet_id UUID NOT NULL

--- a/pollux/sql-doobie/src/main/scala/org/hyperledger/identus/pollux/sql/repository/JdbcOID4VCIIssuerMetadataRepository.scala
+++ b/pollux/sql-doobie/src/main/scala/org/hyperledger/identus/pollux/sql/repository/JdbcOID4VCIIssuerMetadataRepository.scala
@@ -24,6 +24,8 @@ class JdbcOID4VCIIssuerMetadataRepository(xa: Transactor[ContextAwareTask], xb: 
       |SELECT
       |  id,
       |  authorization_server,
+      |  authorization_server_client_id,
+      |  authorization_server_client_secret,
       |  created_at,
       |  updated_at
       |FROM public.issuer_metadata
@@ -42,6 +44,8 @@ class JdbcOID4VCIIssuerMetadataRepository(xa: Transactor[ContextAwareTask], xb: 
       |SELECT
       |  id,
       |  authorization_server,
+      |  authorization_server_client_id,
+      |  authorization_server_client_secret,
       |  created_at,
       |  updated_at
       |FROM public.issuer_metadata
@@ -59,12 +63,16 @@ class JdbcOID4VCIIssuerMetadataRepository(xa: Transactor[ContextAwareTask], xb: 
         |INSERT INTO public.issuer_metadata (
         |  id,
         |  authorization_server,
+        |  authorization_server_client_id,
+        |  authorization_server_client_secret,
         |  created_at,
         |  updated_at,
         |  wallet_id
         |) VALUES (
         |  ${issuer.id},
         |  ${issuer.authorizationServer},
+        |  ${issuer.authorizationServerClientId},
+        |  ${issuer.authorizationServerClientSecret},
         |  ${issuer.createdAt},
         |  ${issuer.updatedAt},
         |  current_setting('app.current_wallet_id')::UUID


### PR DESCRIPTION
### Description: 

- Keycloak plugin add access token when getting nonce from the agent
- oid4vci nonce endpoint has authenticator based on `issuer_state`
- oid4vci credential endpoint has authenticator based on `issuer_id`
- Add authorization server `client_id` and `client_secret` option when creating `CredentialIssuer`
- `ExtendedErrorResponse` has correct `Schema`, `Encoder`, and `Decoder`

### Alternatives Considered (optional): 
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
