### PR TITLE
fix: update issuer auth server model parity

### DIFF
--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/controller/CredentialIssuerController.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/controller/CredentialIssuerController.scala
@@ -261,12 +261,17 @@ case class CredentialIssuerControllerImpl(
   ): ZIO[WalletAccessContext, ErrorResponse, CredentialIssuer] =
     for {
       maybeAuthServerUrl <- ZIO
-        .succeed(request.authorizationServer)
+        .succeed(request.authorizationServer.flatMap(_.url))
         .flatMap {
           case Some(url) => parseURL(url).asSome
           case None      => ZIO.none
         }
-      issuer <- issuerMetadataService.updateCredentialIssuer(issuerId, maybeAuthServerUrl)
+      issuer <- issuerMetadataService.updateCredentialIssuer(
+        issuerId,
+        maybeAuthServerUrl,
+        request.authorizationServer.flatMap(_.clientId),
+        request.authorizationServer.flatMap(_.clientSecret)
+      )
     } yield issuer: CredentialIssuer
 
   override def deleteCredentialIssuer(

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/http/CredentialIssuer.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/http/CredentialIssuer.scala
@@ -25,9 +25,17 @@ object AuthorizationServer {
   given decoder: JsonDecoder[AuthorizationServer] = DeriveJsonDecoder.gen
 }
 
-case class CredentialIssuer(id: UUID, authorizationServer: String)
+case class CredentialIssuer(id: UUID, authorizationServerUrl: String)
 
-case class PatchCredentialIssuerRequest(authorizationServer: Option[String] = None)
+case class PatchAuthorizationServer(url: Option[String], clientId: Option[String], clientSecret: Option[String])
+
+object PatchAuthorizationServer {
+  given schema: Schema[PatchAuthorizationServer] = Schema.derived
+  given encoder: JsonEncoder[PatchAuthorizationServer] = DeriveJsonEncoder.gen
+  given decoder: JsonDecoder[PatchAuthorizationServer] = DeriveJsonDecoder.gen
+}
+
+case class PatchCredentialIssuerRequest(authorizationServer: Option[PatchAuthorizationServer] = None)
 
 object PatchCredentialIssuerRequest {
   given schema: Schema[PatchCredentialIssuerRequest] = Schema.derived

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/repository/OID4VCIIssuerMetadataRepository.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/repository/OID4VCIIssuerMetadataRepository.scala
@@ -11,7 +11,12 @@ trait OID4VCIIssuerMetadataRepository {
   def findIssuerById(issuerId: UUID): UIO[Option[CredentialIssuer]]
   def createIssuer(issuer: CredentialIssuer): URIO[WalletAccessContext, Unit]
   def findWalletIssuers: URIO[WalletAccessContext, Seq[CredentialIssuer]]
-  def updateIssuer(issuerId: UUID, authorizationServer: Option[URL] = None): URIO[WalletAccessContext, Unit]
+  def updateIssuer(
+      issuerId: UUID,
+      authorizationServer: Option[URL] = None,
+      authorizationServerClientId: Option[String] = None,
+      authorizationServerClientSecret: Option[String] = None
+  ): URIO[WalletAccessContext, Unit]
   def deleteIssuer(issuerId: UUID): URIO[WalletAccessContext, Unit]
   def createCredentialConfiguration(issuerId: UUID, config: CredentialConfiguration): URIO[WalletAccessContext, Unit]
   def findCredentialConfigurationsByIssuer(issuerId: UUID): UIO[Seq[CredentialConfiguration]]

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/OID4VCIIssuerMetadataService.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/OID4VCIIssuerMetadataService.scala
@@ -61,7 +61,9 @@ trait OID4VCIIssuerMetadataService {
   def getCredentialIssuers: URIO[WalletAccessContext, Seq[CredentialIssuer]]
   def updateCredentialIssuer(
       issuerId: UUID,
-      authorizationServer: Option[URL] = None
+      authorizationServer: Option[URL] = None,
+      authorizationServerClientId: Option[String] = None,
+      authorizationServerClientSecret: Option[String] = None
   ): ZIO[WalletAccessContext, IssuerIdNotFound, CredentialIssuer]
   def deleteCredentialIssuer(issuerId: UUID): ZIO[WalletAccessContext, IssuerIdNotFound, Unit]
   def createCredentialConfiguration(
@@ -99,11 +101,18 @@ class OID4VCIIssuerMetadataServiceImpl(repository: OID4VCIIssuerMetadataReposito
 
   override def updateCredentialIssuer(
       issuerId: UUID,
-      authorizationServer: Option[URL]
+      authorizationServer: Option[URL],
+      authorizationServerClientId: Option[String],
+      authorizationServerClientSecret: Option[String]
   ): ZIO[WalletAccessContext, IssuerIdNotFound, CredentialIssuer] =
     for {
       _ <- repository
-        .updateIssuer(issuerId, authorizationServer = authorizationServer)
+        .updateIssuer(
+          issuerId = issuerId,
+          authorizationServer = authorizationServer,
+          authorizationServerClientId = authorizationServerClientId,
+          authorizationServerClientSecret = authorizationServerClientSecret
+        )
         .catchSomeDefect { case _: UnexpectedAffectedRow =>
           ZIO.fail(IssuerIdNotFound(issuerId))
         }

--- a/pollux/core/src/test/scala/org/hyperledger/identus/pollux/core/repository/OID4VCIIssuerMetadataRepositorySpecSuite.scala
+++ b/pollux/core/src/test/scala/org/hyperledger/identus/pollux/core/repository/OID4VCIIssuerMetadataRepositorySpecSuite.scala
@@ -98,10 +98,17 @@ object OID4VCIIssuerMetadataRepositorySpecSuite {
         authServer2 = URI.create("http://example-2.com").toURL()
         issuer = makeCredentialIssuer(authorizationServer = authServer1)
         _ <- repo.createIssuer(issuer)
-        _ <- repo.updateIssuer(issuer.id, authorizationServer = Some(authServer2))
+        _ <- repo.updateIssuer(
+          issuerId = issuer.id,
+          authorizationServer = Some(authServer2),
+          authorizationServerClientId = Some("client-2"),
+          authorizationServerClientSecret = Some("secret-2")
+        )
         updatedIssuer <- repo.findIssuerById(issuer.id).some
       } yield assert(updatedIssuer.id)(equalTo(issuer.id)) &&
         assert(updatedIssuer.authorizationServer)(equalTo(authServer2)) &&
+        assert(updatedIssuer.authorizationServerClientId)(equalTo("client-2")) &&
+        assert(updatedIssuer.authorizationServerClientSecret)(equalTo("secret-2")) &&
         assert(updatedIssuer.updatedAt)(not(equalTo(issuer.createdAt)))
     },
     test("update credential issuer with empty patch successfully") {

--- a/pollux/sql-doobie/src/main/scala/org/hyperledger/identus/pollux/sql/repository/JdbcOID4VCIIssuerMetadataRepository.scala
+++ b/pollux/sql-doobie/src/main/scala/org/hyperledger/identus/pollux/sql/repository/JdbcOID4VCIIssuerMetadataRepository.scala
@@ -86,12 +86,18 @@ class JdbcOID4VCIIssuerMetadataRepository(xa: Transactor[ContextAwareTask], xb: 
 
   override def updateIssuer(
       issuerId: UUID,
-      authorizationServer: Option[URL]
+      authorizationServer: Option[URL],
+      authorizationServerClientId: Option[String],
+      authorizationServerClientSecret: Option[String]
   ): URIO[WalletAccessContext, Unit] = {
     val setFr = (now: Instant) =>
       Fragments.set(
         fr"updated_at = $now",
-        (Seq(authorizationServer.map(url => fr"authorization_server = $url")).flatten): _*
+        (Seq(
+          authorizationServer.map(url => fr"authorization_server = $url"),
+          authorizationServerClientId.map(i => fr"authorization_server_client_id = $i"),
+          authorizationServerClientSecret.map(i => fr"authorization_server_client_secret = $i")
+        ).flatten)*
       )
     val cxnIO = (setFr: Fragment) => sql"""
         |UPDATE public.issuer_metadata


### PR DESCRIPTION
### Description: 

`CredentialIssuer` update api should have parity with the create model. Added a `client_id` and `client_secret` patch. 


### Alternatives Considered (optional): 
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
