### PR TITLE
fix: Update the Holder to send the presentation only, No claims to disclose is needed separately 

### DIFF
--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/MockPresentationService.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/MockPresentationService.scala
@@ -12,6 +12,7 @@ import org.hyperledger.identus.pollux.core.model.{DidCommID, PresentationRecord}
 import org.hyperledger.identus.pollux.core.model.error.PresentationError
 import org.hyperledger.identus.pollux.core.model.presentation.{Options, SdJwtPresentationPayload}
 import org.hyperledger.identus.pollux.core.service.serdes.{AnoncredCredentialProofsV1, AnoncredPresentationRequestV1}
+import org.hyperledger.identus.pollux.sdjwt.PresentationJson
 import org.hyperledger.identus.pollux.vc.jwt.{Issuer, PresentationPayload, W3cCredentialPayload}
 import org.hyperledger.identus.shared.models.WalletAccessContext
 import zio.{mock, IO, URLayer, ZIO, ZLayer}
@@ -210,7 +211,7 @@ object MockPresentationService extends Mock[PresentationService] {
       override def createSDJwtPresentationPayloadFromRecord(
           record: DidCommID,
           issuer: Issuer,
-      ): IO[PresentationError, SdJwtPresentationPayload] = ???
+      ): IO[PresentationError, PresentationJson] = ???
 
       def createSDJwtPresentation(
           recordId: DidCommID,

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationService.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationService.scala
@@ -7,6 +7,7 @@ import org.hyperledger.identus.pollux.core.model.*
 import org.hyperledger.identus.pollux.core.model.error.PresentationError
 import org.hyperledger.identus.pollux.core.model.presentation.*
 import org.hyperledger.identus.pollux.core.service.serdes.{AnoncredCredentialProofsV1, AnoncredPresentationRequestV1}
+import org.hyperledger.identus.pollux.sdjwt.PresentationJson
 import org.hyperledger.identus.pollux.vc.jwt.*
 import org.hyperledger.identus.shared.models.WalletAccessContext
 import zio.*
@@ -59,7 +60,7 @@ trait PresentationService {
   def createSDJwtPresentationPayloadFromRecord(
       record: DidCommID,
       issuer: Issuer,
-  ): ZIO[WalletAccessContext, PresentationError, SdJwtPresentationPayload]
+  ): ZIO[WalletAccessContext, PresentationError, PresentationJson]
 
   def createSDJwtPresentation(
       recordId: DidCommID,

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceImpl.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceImpl.scala
@@ -112,7 +112,7 @@ private class PresentationServiceImpl(
   override def createSDJwtPresentationPayloadFromRecord(
       recordId: DidCommID,
       prover: Issuer
-  ): ZIO[WalletAccessContext, PresentationError, SdJwtPresentationPayload] = {
+  ): ZIO[WalletAccessContext, PresentationError, PresentationJson] = {
 
     for {
       maybeRecord <- presentationRepository
@@ -144,7 +144,7 @@ private class PresentationServiceImpl(
           )
         )
       )
-
+      // return presentationJson
       presentationJson <- createSDJwtPresentationPayloadFromCredential(
         issuedCredentials,
         sdJwtClaimsToDisclose,
@@ -159,7 +159,7 @@ private class PresentationServiceImpl(
         )
       )
 
-    } yield presentationPayload
+    } yield presentationJson
   }
 
   override def createSDJwtPresentation(
@@ -178,7 +178,7 @@ private class PresentationServiceImpl(
           attachments = Seq(
             AttachmentDescriptor
               .buildBase64Attachment(
-                payload = presentationPayload.toJson.getBytes,
+                payload = presentationPayload.value.getBytes,
                 mediaType = Some(PresentCredentialFormat.SDJWT.name)
               )
           ),

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceNotifier.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceNotifier.scala
@@ -13,6 +13,7 @@ import org.hyperledger.identus.pollux.core.model.{DidCommID, PresentationRecord}
 import org.hyperledger.identus.pollux.core.model.error.PresentationError
 import org.hyperledger.identus.pollux.core.model.presentation.{Options, SdJwtPresentationPayload}
 import org.hyperledger.identus.pollux.core.service.serdes.{AnoncredCredentialProofsV1, AnoncredPresentationRequestV1}
+import org.hyperledger.identus.pollux.sdjwt.PresentationJson
 import org.hyperledger.identus.pollux.vc.jwt.{Issuer, PresentationPayload, W3cCredentialPayload}
 import org.hyperledger.identus.shared.models.WalletAccessContext
 import zio.{IO, URLayer, ZIO, ZLayer}
@@ -204,7 +205,7 @@ class PresentationServiceNotifier(
   override def createSDJwtPresentationPayloadFromRecord(
       record: DidCommID,
       issuer: Issuer
-  ): ZIO[WalletAccessContext, PresentationError, SdJwtPresentationPayload] =
+  ): ZIO[WalletAccessContext, PresentationError, PresentationJson] =
     svc.createSDJwtPresentationPayloadFromRecord(record, issuer)
 
   override def createSDJwtPresentation(

--- a/pollux/sd-jwt/src/main/scala/org/hyperledger/identus/pollux/sdjwt/SDJWT.scala
+++ b/pollux/sd-jwt/src/main/scala/org/hyperledger/identus/pollux/sdjwt/SDJWT.scala
@@ -129,7 +129,6 @@ object SDJWT {
   def getVerifiedClaims(
       key: IssuerPublicKey,
       presentation: PresentationJson,
-      claims: String
   ): ClaimsValidationResult = {
     Try {
       val verifier = SdjwtVerifierWrapper(

--- a/pollux/sd-jwt/src/test/scala/org/hyperledger/identus/pollux/sdjwt/SDJWTSpec.scala
+++ b/pollux/sd-jwt/src/test/scala/org/hyperledger/identus/pollux/sdjwt/SDJWTSpec.scala
@@ -119,7 +119,8 @@ object SDJWTSpec extends ZIOSpecDefault {
     test("getVerifiedClaims presentation") {
       val credential = SDJWT.issueCredential(ISSUER_KEY, CLAIMS)
       val presentation = SDJWT.createPresentation(credential, CLAIMS_QUERY)
-      val ret = SDJWT.getVerifiedClaims(ISSUER_KEY_PUBLIC, presentation, CLAIMS_PRESENTED)
+      println(presentation)
+      val ret = SDJWT.getVerifiedClaims(ISSUER_KEY_PUBLIC, presentation)
       assertTrue(
         """{"iss":"did:example:issuer","iat":1683000000,"exp":1883000000,"address":{"country":"DE"}}"""
           .fromJson[ast.Json.Obj]
@@ -129,8 +130,9 @@ object SDJWTSpec extends ZIOSpecDefault {
     },
     test("issue credential without sub & iat and getVerifiedClaims") {
       val credential = SDJWT.issueCredential(ISSUER_KEY, CLAIMS_WITHOUT_SUB_IAT)
+      // verfier asking to disclose
       val presentation = SDJWT.createPresentation(credential, CLAIMS_QUERY)
-      val ret = SDJWT.getVerifiedClaims(ISSUER_KEY_PUBLIC, presentation, CLAIMS_PRESENTED)
+      val ret = SDJWT.getVerifiedClaims(ISSUER_KEY_PUBLIC, presentation)
       assertTrue(
         """{"iss":"did:example:issuer","exp":1883000000,"address":{"country":"DE"}}"""
           .fromJson[ast.Json.Obj]
@@ -215,6 +217,7 @@ object SDJWTSpec extends ZIOSpecDefault {
       val issuerPublicKey = IssuerPublicKey(ed25519KeyPair.publicKey)
 
       val credential = SDJWT.issueCredential(issuerKey, CLAIMS)
+      // verifer addres
       val presentation = SDJWT.createPresentation(credential, CLAIMS_PRESENTED)
       val ret = SDJWT.verifyAndComparePresentation(issuerPublicKey, presentation, CLAIMS_PRESENTED)
       assertTrue(ret == SDJWT.ValidAnyMatch)


### PR DESCRIPTION
### Description: 
This change allows the Holder to make a presentation without sending the claims to be disclosed separately. As a result, the DIDComm attachment will only contain the presentation
https://input-output.atlassian.net/browse/ATL-7240
### Alternatives Considered (optional): 
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
