### PR TITLE
feat: use kid in the jwt proof header of OID4VCI CredentialIssue request

### DIFF
--- a/castor/src/main/scala/org/hyperledger/identus/castor/core/model/did/DIDUrl.scala
+++ b/castor/src/main/scala/org/hyperledger/identus/castor/core/model/did/DIDUrl.scala
@@ -1,8 +1,63 @@
 package org.hyperledger.identus.castor.core.model.did
 
+import scala.collection.immutable.ListMap
+
 final case class DIDUrl(
     did: DID,
     path: Seq[String],
-    parameters: Map[String, Seq[String]],
+    parameters: ListMap[String, Seq[String]],
     fragment: Option[String]
-)
+) {
+
+  override def toString: String = {
+    val pathString = if (path.isEmpty) "" else path.mkString("/", "/", "")
+    val queryString =
+      if (parameters.isEmpty) ""
+      else parameters.map { case (key, values) => s"$key=${values.mkString(",")}" }.mkString("?", "&", "")
+    val fragmentString = fragment.map("#" + _).getOrElse("")
+
+    s"did:${did.method}:${did.methodSpecificId}$pathString$queryString$fragmentString"
+  }
+}
+
+object DIDUrl {
+  def fromString(url: String): Either[String, DIDUrl] = {
+    val DIDUrlPattern = """^(did:[^/?#&]*)(/[^?#]*)?(\?[^#]*)?(#.*)?""".r
+
+    url match {
+      case DIDUrlPattern(did, path, query, fragment) =>
+        for {
+          parsedDID <- DID.fromString(did)
+        } yield {
+          DIDUrl(
+            did = parsedDID,
+            path = Option(path).map(_.stripPrefix("/").split("/").toSeq).getOrElse(Seq.empty),
+            parameters = Option(query).map(parseQuery).getOrElse(ListMap.empty),
+            fragment = Option(fragment).map(_.stripPrefix("#"))
+          )
+        }
+    }
+  }
+
+  // This method preserves the order of the query parameters to return absolutely the same result as the original query string for testing purposes
+  private def parseQuery(query: String): ListMap[String, Seq[String]] = {
+    val params = query
+      .stripPrefix("?")
+      .split("&")
+      .toSeq
+      .map { param =>
+        param.split("=", 2) match {
+          case Array(key, value) => key -> value
+          case Array(key)        => key -> ""
+        }
+      }
+
+    var listMap = ListMap.empty[String, Seq[String]]
+
+    params.foreach { case (key, value) =>
+      listMap = listMap.updated(key, listMap.getOrElse(key, Seq.empty) :+ value)
+    }
+
+    listMap
+  }
+}

--- a/castor/src/test/scala/org/hyperledger/identus/castor/core/model/did/DIDUrlSpec.scala
+++ b/castor/src/test/scala/org/hyperledger/identus/castor/core/model/did/DIDUrlSpec.scala
@@ -1,0 +1,115 @@
+package org.hyperledger.identus.castor.core.model.did
+
+import org.hyperledger.identus.castor.core.util.GenUtils
+import zio.*
+import zio.test.*
+import zio.test.assert
+import zio.test.Assertion.*
+import zio.test.Assertion.isLeft
+
+object DIDUrlSpec extends ZIOSpecDefault {
+  override def spec = suite("DIDUrl")(fromStringSpec)
+
+  /*
+   * Getting test inputs
+   *
+   * git clone https://github.com/w3c/did-test-suite.git
+   * cd did-test-suite
+   * cd packages/did-core-test-server/suites/implementations
+   * find . -name 'did-*.json' -exec bash -c "cat {} | jq '.dids' | grep 'did:'" \;
+   */
+  val DIDTestSuite = Seq(
+    "did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
+    "did:algo:56da1708-eead-4e2d-9558-f53d684003fd",
+    "did:art:enq:f045c5c7d50145b65ca2702c38b4e2d46658293c",
+    "did:cheqd:mainnet:zF7rhDBfUt9d1gJPjx7s1JXfUY7oVWkY",
+    "did:ebsi:znHeZWvhAK2FK2Dk1jXNe7m",
+    "did:elem:ropsten:EiBVk9F3eLf2u9xwLJ91-vTIXD-B7Q4m3iGhCbB2OyRiwQ",
+    "did:ethr:0x26bf14321004e770e7a8b080b7a526d8eed8b388",
+    "did:example:123",
+    "did:ion:EiCUAQbYJzzCY1zL8KYmTu8MxCkFwG_cjRcZI2bRpwDQkQ:eyJkZWx0YSI6eyJwYXRjaGVzIjpbeyJhY3Rpb24iOiJyZXBsYWNlIiwiZG9jdW1lbnQiOnsicHVibGljS2V5cyI6W3siaWQiOiJzaWdfMDY0YmViY2MiLCJwdWJsaWNLZXlKd2siOnsiY3J2Ijoic2VjcDI1NmsxIiwia3R5IjoiRUMiLCJ4IjoibHV2TG1tbEc0NFZmcWx1aFh3SWpTdVQxVEwxc0VfMTFnQ0RlazJQbXVpbyIsInkiOiJ0WURKWmFpWDdBN2tydmNhcEFnS0pGNjd6ejVKUzF3bjRGdWNqa09kUUVvIn0sInB1cnBvc2VzIjpbImF1dGhlbnRpY2F0aW9uIiwiYXNzZXJ0aW9uTWV0aG9kIl0sInR5cGUiOiJFY2RzYVNlY3AyNTZrMVZlcmlmaWNhdGlvbktleTIwMTkifV0sInNlcnZpY2VzIjpbeyJpZCI6ImxpbmtlZGRvbWFpbnMiLCJzZXJ2aWNlRW5kcG9pbnQiOnsib3JpZ2lucyI6WyJodHRwczovL2FkbWluLXRlc3RzLWRvbWFpbi5jb20vIl19LCJ0eXBlIjoiTGlua2VkRG9tYWlucyJ9XX19XSwidXBkYXRlQ29tbWl0bWVudCI6IkVpQi13MlVfbW5aRUVRWmRoNUNsVWszMERBdjZrTXNMT05TSWdxaGp5WEluLUEifSwic3VmZml4RGF0YSI6eyJkZWx0YUhhc2giOiJFaURyNk1nVWtSSm9maGVqTW96VXVoSXBSX0tFa3J1WlZGaDlheHVzS2I5cnFRIiwicmVjb3ZlcnlDb21taXRtZW50IjoiRWlBS1VxUmJTTkJKSHFUQTljbXJ1MnBtQkVvd2tIVVFVLW9CS3Q3NWQ3QU8wQSJ9fQ",
+    "did:is:PMW1Ks7h4brpN8FdDVLwhPDKJ7LdA7mVdd",
+    "did:jnctn:187c4af8932a444a9e9503fb96cb672f",
+    "did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7",
+    "did:key:z5TcCQtximJCYYLLmpUhydMUfyppwqQFveNQcrmLxYqbCvDrrcu9rVrHwNZEN37CWMUBRd8xgEyPighrGMMmX8NWTnSPUuWPPeFyUhLmkgA1Vqgm3eQYHF4ye7WrkB7jYcWoa68oHQNuSzw6ezgebFtt27uvJG4yjdat8Wj1e2qPMjsR63xQbmNdDTQ4zi8GDz8EwVAgu",
+    "did:key:z6LSn9Ah7d33uokFv2pg66BMN5UY72WtPE6eFjGXrA4mPcCp",
+    "did:key:z6MkjPrEBMHGuJubLZ5HWf2jBreAuh7onKCA6BknWXYHLxjS",
+    "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+    "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+    "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+    "did:key:z6MktZw8HgaRUoG8S9asnmDKQL458uEhuuNT9U2UK5cT6Tmh",
+    "did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9",
+    "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169",
+    "did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv",
+    "did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme",
+    "did:key:zQ3shwNhfEjorJrrKpqvBvNRV35NfGmVWdx2rNmQCRR58Sfpf",
+    "did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV",
+    "did:kilt:04siJtc4dYq2gPre8Xj6KJcSjVAdi1gmjctUzjf3AwrtNnhvy",
+    "did:kilt:14siJtc4dYq2gPre8Xj6KJcSjVAdi1gmjctUzjf3AwrtNnhvy",
+    "did:lit:AEZ87t1bi5bRxmVh3ksMUi",
+    "did:monid:1fb352353ff51248c5104b407f9c04c3666627fcf5a167d693c9fc84b75964e2",
+    "did:nft:eip155.1_erc721.0xb300a43751601bd54ffee7de35929537b28e1488_2",
+    "did:onion:fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid",
+    "did:orb:bafkreiazah4qrybzyapmrmk2dhldz24vfmavethcrgcoq7qhic63zz55ru:EiAag4cmgxAE2isL5HG3mxjS7WRq4l-xyyTgULCAcEHQQQ",
+    "did:orb:bafkreibcsubh3ifub7gletz27hcdyhwvrhlh5mwfth2m5fbasqua6yalay:EiA2ZtZqXjKZt-yf19ersmaCYm-gJEnlixrfk0Mi61ETTg",
+    "did:orb:bafkreihp4inweep4py7gw4j7hej5mqlbwa7br4u7mtrfxr5khfwpu3qu3m:EiB2tmdM_oWwjXj6AmVLm0RFa_8XKZHipOpNGpEODIVN8Q",
+    "did:orb:interim:EiAQ1HmY03Cx4OMhiuYHl8q-B1JYlkT1Wns-dhhccUIl5g:eyJkZWx0YSI6eyJwYXRjaGVzIjpbeyJhY3Rpb24iOiJhZGQtcHVibGljLWtleXMiLCJwdWJsaWNLZXlzIjpbeyJpZCI6ImNyZWF0ZUtleSIsInB1YmxpY0tleUp3ayI6eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6InJILURtZmNkRVZERi1vNm80ellxdjl2YlhPcFFFcDd3RC1XUHFDbl9ELXciLCJ5IjoidnBiRGNQX2YwS1JoRW02Sm93Y0oxbWlNTldJRXo2YWVnRHFDek80WXNxSSJ9LCJwdXJwb3NlcyI6WyJhdXRoZW50aWNhdGlvbiJdLCJ0eXBlIjoiSnNvbldlYktleTIwMjAifSx7ImlkIjoiYXV0aCIsInB1YmxpY0tleUp3ayI6eyJjcnYiOiJFZDI1NTE5Iiwia3R5IjoiT0tQIiwieCI6IjEzNkZDRjJTSEZNMUZ6aWlJYXJwNEI1RzkxUVNnNHB1dGFhSWg1VEdXREEiLCJ5IjoiIn0sInB1cnBvc2VzIjpbImFzc2VydGlvbk1ldGhvZCJdLCJ0eXBlIjoiRWQyNTUxOVZlcmlmaWNhdGlvbktleTIwMTgifV19LHsiYWN0aW9uIjoiYWRkLXNlcnZpY2VzIiwic2VydmljZXMiOlt7ImlkIjoiZGlkY29tbSIsInByaW9yaXR5IjowLCJyZWNpcGllbnRLZXlzIjpbIjZLWjZLQkZLZDQ3d3FEMlhnelJwTDZ0RGlxQkNnQzg1eEttbzhVRHExZjVSIl0sInJvdXRpbmdLZXlzIjpbIjhrNUY0bXVQN0s3NmVtZHdQNWlDOHJlRVlWb1NiWmdMM2FudmFXOTdUTm1yIl0sInNlcnZpY2VFbmRwb2ludCI6Imh0dHBzOi8vaHViLmV4YW1wbGUuY29tLy5pZGVudGl0eS9kaWQ6ZXhhbXBsZTowMTIzNDU2Nzg5YWJjZGVmLyIsInR5cGUiOiJkaWQtY29tbXVuaWNhdGlvbiJ9XX1dLCJ1cGRhdGVDb21taXRtZW50IjoiRWlEVXVaSFEwOENXRGVBTmJyc3VSeHh3M2V5bXNucFdNbzJ0TXQ3QUNlUUNIUSJ9LCJzdWZmaXhEYXRhIjp7ImFuY2hvck9yaWdpbiI6Imh0dHBzOi8vb3JiLmRvbWFpbjEuY29tL3NlcnZpY2VzL29yYiIsImRlbHRhSGFzaCI6IkVpQUluS05tb0d1WDJVajI1aGFCNDdGQlF4aGpmb0lJYzc3Y2h6N0p0enJXdVEiLCJyZWNvdmVyeUNvbW1pdG1lbnQiOiJFaUNIOWF3WHZQUFZZdVBneEw2WUFQX3FaeUktMzdxclcwQkdFT2o5cnJWbHd3In19",
+    "did:orb:interim:EiCYgffdSsqLTXT6PRYLPr6vvgn9PVecJ5nFUGh9hXgOxQ",
+    "did:orb:interim:EiDHdXhNm7LuCqxo4JvAwKYKiFmpf85YFswAovxTxI_y4Q",
+    "did:orb:ipfs:QmS4ZME5uEPtQ2DFDwhSZYtLxzFxCYjJ6kC7o3ypwanzFm:EiACG5GI9dK1fjnCMYMA6ZFhtP75HVhunEuqW-XDCAU7Ew",
+    "did:orb:ipfs:QmfJFePqcopDUYttpvWgec9LKeJhnwh4UjhwUJz5ZcRUqM:EiDwFxa7ooPvKDTqpemH-R-H0pNX9VzUEUzk8AZsMCf9pg",
+    "did:orb:ipfs:QmfX6CHk7AC43Xq9iFK9XzgH3a7kJeAn3ewWZxEcqur2wE:EiCnmXoUEEP-04kELpPiF7Ss5GesCCedfTgRPA30SJO5KQ",
+    "did:orb:ipfs:bafkreiacr3ga6zilvzatpcixq5mz4uvgld7yedutgcssvnmql44o6rc7yy:EiB2k0ytmo-qi_M7jGocxvj4P9D6VQJGl6gRy4f6-UUpTw",
+    "did:orb:webcas:testnet.orb.local:bafkreihdnftiso5b7bzmhhi65nzsutbcuv6mtrmuquzoqlrk7joyer45uq:EiARiEOCLK3GnRVHA_yF92tX3aoSJAVqW1bh7Enre1iDXw",
+    "did:photon:EiDS68FUZqv0da57WLI_t9Gl5TYGNxvWR3PGgRk9oXx85Q",
+    "did:pkh:btc:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6",
+    "did:pkh:celo:0xa0ae58da58dfa46fa55c3b86545e7065f90ff011",
+    "did:pkh:doge:DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L",
+    "did:pkh:eth:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+    "did:pkh:sol:CKg5d12Jhpej1JqtmxLJgaFqqeYjxgPqToJ4LBdvG9Ev",
+    "did:pkh:tz:tz1YwA1FwpgLtc1G8DKbbZ6e6PTb1dQMRn5x",
+    "did:polygon:0xBCFdE12C425E4CbDb45226Fe51F89F2d99667d3E",
+    "did:schema:public-ipfs:xsd:QmUQAxKQ5sbWWrcBZzwkThktfUGZvuPQyTrqMzb3mZnLE5",
+    "did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP",
+    "did:ssb:ed25519:f_6sQ6d2CMxRUhLpspgGIulDxDCwYD7DzFzPNr7u5AU",
+    "did:trust:tc:dev:id:GvMM3dpmWH6mRhGK88Ykdh",
+    "did:tz:delphinet:tz1WvvbEGpBXGeTVbLiR6DYBe1izmgiYuZbq",
+    "did:tz:tz1YwA1FwpgLtc1G8DKbbZ6e6PTb1dQMRn5x",
+    "did:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq",
+    "did:tz:tz3agP9LGe2cXmKQyYn6T68BHKjjktDbbSWX",
+    "did:unisot:test:mtF5XVLJvXEeffY8fo2eUfpXqs9CqQzpj7",
+    "did:v1:nym:z6Mkh18zyRvTikTTYwi3p4S8kQNqLkExDamQHERxeB34AMvL",
+    "did:vaa:2H9XwzRXZ1o5ZwSoYDEZn24eHXcQ",
+    "did:web:demo.spruceid.com:2021:07:08",
+    "did:web:did.actor:healthcare:doctor:robert",
+    "did:web:did.actor:mike",
+    "did:web:did.actor:mike",
+    "did:web:evernym.com",
+    "did:web:kyledenhartog.com",
+    "did:web:or13.github.io:deno-did-pm",
+    "did:webkey:ssh:demo.spruceid.com:2021:07:14:keys",
+  )
+
+  val numberOfSamples = 1000
+
+  private val fromStringSpec = suite("DIDUrl.fromString")(
+    test("parse any valid long-form or canonical form PRISM DID Url") {
+      check(GenUtils.prismDIDUrlGen) { prismDIDRUrl =>
+        val parsed = DIDUrl.fromString(prismDIDRUrl)
+        assert(parsed.map(_.toString))(isRight(equalTo(prismDIDRUrl)))
+      }
+    } @@ TestAspect.samples(numberOfSamples),
+    test("parse all DIDs from https://github.com/w3c/did-test-suite.git as DIDUrl") {
+      check(Gen.fromIterable(DIDTestSuite)) { didUrl =>
+        val parsed = DIDUrl.fromString(didUrl)
+        assert(parsed.map(_.toString))(isRight(equalTo(didUrl)))
+      }
+    } @@ TestAspect.samples(numberOfSamples),
+    test("parse all DIDs from https://github.com/w3c/did-test-suite.git with path, query and fragment as DIDUrl") {
+      check(GenUtils.inputDIDUrlGen(DIDTestSuite)) { didUrl =>
+        val parsed = DIDUrl.fromString(didUrl)
+        assert(parsed.map(_.toString))(isRight(equalTo(didUrl)))
+      }
+    } @@ TestAspect.samples(numberOfSamples)
+  )
+}

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/controller/CredentialIssuerController.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/controller/CredentialIssuerController.scala
@@ -174,7 +174,8 @@ case class CredentialIssuerControllerImpl(
           session <- credentialIssuerService
             .getIssuanceSessionByNonce(nonce)
             .mapError(_ => badRequestInvalidProof(jwt, "nonce is not associated to the issuance session"))
-          subjectDid <- getSubjectDIDFromJwt(JWT(jwt))
+          subjectDid <- parseDIDUrlFromKeyId(JWT(jwt))
+            .map(_.did)
             .mapError(throwable => badRequestInvalidProof(jwt, throwable.getMessage))
           sessionWithSubjectDid <- credentialIssuerService
             .updateIssuanceSession(session.withSubjectDid(subjectDid))
@@ -191,9 +192,9 @@ case class CredentialIssuerControllerImpl(
             )
           credential <- credentialIssuerService
             .issueJwtCredential(
-              session.issuingDid,
-              session.subjectDid,
-              session.claims,
+              sessionWithSubjectDid.issuingDid,
+              sessionWithSubjectDid.subjectDid,
+              sessionWithSubjectDid.claims,
               maybeCredentialIdentifier,
               validatedCredentialDefinition
             )

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/service/OIDCCredentialIssuerService.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/service/OIDCCredentialIssuerService.scala
@@ -3,11 +3,12 @@ package org.hyperledger.identus.oid4vci.service
 import io.circe.parser.parse
 import io.circe.Json
 import org.hyperledger.identus.agent.walletapi.storage.DIDNonSecretStorage
-import org.hyperledger.identus.castor.core.model.did.{DID, PrismDID, VerificationRelationship}
-import org.hyperledger.identus.oid4vci.domain.IssuanceSession
+import org.hyperledger.identus.castor.core.model.did.{DID, DIDUrl, PrismDID, VerificationRelationship}
+import org.hyperledger.identus.oid4vci.domain.{IssuanceSession, Openid4VCIProofJwtOps}
 import org.hyperledger.identus.oid4vci.http.*
 import org.hyperledger.identus.oid4vci.storage.IssuanceSessionStorage
 import org.hyperledger.identus.pollux.core.model.schema.CredentialSchema
+import org.hyperledger.identus.pollux.vc.jwt.*
 import org.hyperledger.identus.pollux.core.service.{
   CredentialService,
   OID4VCIIssuerMetadataService,
@@ -27,6 +28,7 @@ import org.hyperledger.identus.shared.models.{WalletAccessContext, WalletId}
 import zio.*
 
 import java.net.URL
+import java.security.PublicKey
 import java.time.Instant
 import java.util.UUID
 import scala.util.Try
@@ -104,21 +106,41 @@ case class OIDCCredentialIssuerServiceImpl(
     issuanceSessionStorage: IssuanceSessionStorage,
     didResolver: DidResolver,
     uriDereferencer: URIDereferencer,
-) extends OIDCCredentialIssuerService {
+) extends OIDCCredentialIssuerService
+    with Openid4VCIProofJwtOps {
 
   import OIDCCredentialIssuerService.Error
   import OIDCCredentialIssuerService.Errors.*
 
+  private def resolveVerificationMethodByKeyId(didUrl: DIDUrl): IO[DIDResolutionError, VerificationMethod] = {
+    for {
+      didDocument <- JWTVerification
+        .resolve(didUrl.did.toString)(didResolver)
+        .flatMap(_.toZIO)
+        .mapError(msg => DIDResolutionError(s"Failed to resolve DID: $msg"))
+      verificationMethodKeyOpt = didDocument.verificationMethod
+        .find(_.id == didUrl.toString)
+      assertionMethodKeyOpt = didDocument.assertionMethod
+        .filter(m => m.isInstanceOf[VerificationMethod])
+        .map(_.asInstanceOf[VerificationMethod])
+        .find(_.id == didUrl.toString)
+      verificationMethod <- ZIO
+        .fromOption(verificationMethodKeyOpt.orElse(assertionMethodKeyOpt))
+        .mapError(_ => DIDResolutionError(s"Verification method not found for keyId: ${didUrl.toString}"))
+    } yield verificationMethod
+  }
+
   override def verifyJwtProof(jwt: JWT): IO[InvalidProof, Boolean] = {
     for {
-      verifiedJwtSignature <- JWTVerification
-        .validateEncodedJwtWithKeyId(
-          jwt,
-          proofPurpose = Some(VerificationRelationship.AssertionMethod),
-          didResolver = didResolver
-        )
-        .mapError(InvalidProof.apply)
-      _ <- verifiedJwtSignature.toZIO.mapError(InvalidProof.apply)
+      algorithm <- getAlgorithmFromJwt(jwt)
+        .mapError(e => InvalidProof(e.getMessage))
+      didUrl <- parseDIDUrlFromKeyId(jwt)
+        .mapError(e => InvalidProof(e.getMessage))
+      verificationMethod <- resolveVerificationMethodByKeyId(didUrl)
+        .mapError(dre => InvalidProof(dre.message))
+      publicKey <- JWTVerification.extractPublicKey(verificationMethod).toZIO.mapError(InvalidProof.apply)
+      _ <- JWTVerification.validateEncodedJwt(jwt, publicKey).toZIO.mapError(InvalidProof.apply)
+      _ <- ZIO.succeed(println(s"JWT proof is verified: ${jwt.value}")) // TODO: remove before the release
     } yield true
   }
 

--- a/cloud-agent/service/server/src/test/scala/org/hyperledger/identus/oid4vci/domain/OIDCCredentialIssuerServiceSpec.scala
+++ b/cloud-agent/service/server/src/test/scala/org/hyperledger/identus/oid4vci/domain/OIDCCredentialIssuerServiceSpec.scala
@@ -1,6 +1,7 @@
 package org.hyperledger.identus.oid4vci.domain
 
 import com.nimbusds.jose.*
+import org.bouncycastle.util.encoders.Hex
 import org.hyperledger.identus.agent.walletapi.memory.GenericSecretStorageInMemory
 import org.hyperledger.identus.agent.walletapi.service.{ManagedDIDService, MockManagedDIDService}
 import org.hyperledger.identus.agent.walletapi.storage.{DIDNonSecretStorage, MockDIDNonSecretStorage}
@@ -11,11 +12,7 @@ import org.hyperledger.identus.oid4vci.service.{OIDCCredentialIssuerService, OID
 import org.hyperledger.identus.oid4vci.storage.InMemoryIssuanceSessionService
 import org.hyperledger.identus.pollux.core.model.oid4vci.CredentialConfiguration
 import org.hyperledger.identus.pollux.core.model.CredentialFormat
-import org.hyperledger.identus.pollux.core.repository.{
-  CredentialRepository,
-  CredentialRepositoryInMemory,
-  CredentialStatusListRepositoryInMemory
-}
+import org.hyperledger.identus.pollux.core.repository.{CredentialRepository, CredentialRepositoryInMemory, CredentialStatusListRepositoryInMemory}
 import org.hyperledger.identus.pollux.core.service.*
 import org.hyperledger.identus.pollux.vc.jwt.PrismDidResolver
 import org.hyperledger.identus.shared.models.{WalletAccessContext, WalletId}
@@ -91,7 +88,14 @@ object OIDCCredentialIssuerServiceSpec
 
   private def buildJwtProof(nonce: String, aud: UUID, iat: Int) = {
     val longFormDid = PrismDID.buildLongFormFromOperation(holderOp)
-    makeJwtProof(longFormDid, nonce, aud, iat, holderKp.privateKey)
+    val keyIndex = holderDidData.publicKeys.find(_.purpose == VerificationRelationship.AssertionMethod).get.id
+    val kid = longFormDid.toString + "#" + keyIndex
+
+    val encodedKey = Hex.toHexString(holderKp.privateKey.getEncoded)
+    println(s"Private Key: $encodedKey")
+    println("kid: " + longFormDid.toString)
+
+    makeJwtProof(kid, nonce, aud, iat, holderKp.privateKey)
   }
 
   private val validateProofSpec = suite("Validate holder's proof of possession using the LongFormPrismDID")(

--- a/examples/st-oid4vci/demo.py
+++ b/examples/st-oid4vci/demo.py
@@ -237,7 +237,7 @@ def holder_get_credential(credential_endpoint: str, token_response):
     jwt_proof = jwt.encode(
         headers={
             "typ": "openid4vci-proof+jwt",
-            "kid": HOLDER_LONG_FORM_DID,
+            "kid": HOLDER_LONG_FORM_DID + "#key-0",
         },
         payload={
             "iss": ALICE_CLIENT_ID,

--- a/pollux/vc-jwt/src/main/scala/org/hyperledger/identus/pollux/vc/jwt/JWTVerification.scala
+++ b/pollux/vc-jwt/src/main/scala/org/hyperledger/identus/pollux/vc/jwt/JWTVerification.scala
@@ -132,61 +132,6 @@ object JWTVerification {
       })
   }
 
-  def keyIdDIDExtractor(jwt: JWT): Validation[String, String] = {
-    for {
-      header <- Validation
-        .fromTry(
-          JwtCirce
-            .decodeAll(jwt.value, JwtOptions(false, false, false))
-            .map(_._1)
-        )
-        .mapError(_.getMessage)
-      keyId <- Validation.fromOptionWith("Key ID not found in JWT header")(header.keyId)
-      isValidPrismDID <- Validation.fromEither(PrismDID.fromString(keyId)) // TODO: we don't support other DIDs yet
-    } yield keyId
-  }
-
-  def validateEncodedJwtWithKeyId(
-      jwt: JWT,
-      proofPurpose: Option[VerificationRelationship] = None,
-      didResolver: DidResolver,
-      didExtractor: JWT => Validation[String, String] = keyIdDIDExtractor
-  ): IO[String, Validation[String, Unit]] = {
-    val decodedJWT = Validation
-      .fromTry(JwtCirce.decodeRawAll(jwt.value, JwtOptions(false, false, false)))
-      .mapError(_.getMessage)
-
-    val extractAlgorithm: Validation[String, JwtAlgorithm] =
-      for {
-        decodedJwtTask <- decodedJWT
-        (header, _, _) = decodedJwtTask
-        algorithm <- Validation
-          .fromOptionWith("An algorithm must be specified in the header")(JwtCirce.parseHeader(header).algorithm)
-      } yield algorithm
-
-    val claim: Validation[String, String] =
-      for {
-        decodedJwtTask <- decodedJWT
-        (_, claim, _) = decodedJwtTask
-      } yield claim
-
-    val extractedDID = didExtractor(jwt)
-
-    val loadDidDocument = validateIssuerFromKeyId(extractedDID)(didResolver)
-
-    loadDidDocument
-      .map(validatedDidDocument => {
-        for {
-          results <- Validation.validateWith(validatedDidDocument, extractAlgorithm)((didDocument, algorithm) =>
-            (didDocument, algorithm)
-          )
-          (didDocument, algorithm) = results
-          verificationMethods <- extractVerificationMethods(didDocument, algorithm, proofPurpose)
-          validatedJwt <- validateEncodedJwt(jwt, verificationMethods)
-        } yield validatedJwt
-      })
-  }
-
   def toECDSAVerifier(publicKey: PublicKey): JWSVerifier = {
     val verifier: JWSVerifier = publicKey match {
       case key: ECPublicKey => ECDSAVerifier(key)
@@ -223,7 +168,7 @@ object JWTVerification {
       .reduce((v1, v2) => v1.orElse(v2))
   }
 
-  private def resolve(issuerDid: String)(didResolver: DidResolver): IO[String, Validation[String, DIDDocument]] = {
+  def resolve(issuerDid: String)(didResolver: DidResolver): IO[String, Validation[String, DIDDocument]] = {
     didResolver
       .resolve(issuerDid)
       .map(
@@ -251,14 +196,8 @@ object JWTVerification {
     // might not be in the same DID document. For now, this only performs lookup within
     // the same DID document which is what Prism DID currently support.
 
-    val dereferencedKeysToCheck: Vector[VerificationMethod] = {
-      val (referenced, embedded) = publicKeysToCheck.partitionMap[String, VerificationMethod] {
-        case uri: String            => Left(uri)
-        case pk: VerificationMethod => Right(pk)
-      }
-      val keySet = referenced.toSet
-      embedded ++ didDocument.verificationMethod.filter(pk => keySet.contains(pk.id))
-    }
+    val dereferencedKeysToCheck = dereferenceVerificationMethods(didDocument, publicKeysToCheck)
+
     Validation
       .fromPredicateWith("No PublicKey to validate against found")(
         dereferencedKeysToCheck.filter { verification =>
@@ -266,6 +205,18 @@ object JWTVerification {
           supportPublicKeys.contains(verification.`type`)
         }
       )(_.nonEmpty)
+  }
+
+  def dereferenceVerificationMethods(
+      didDocument: DIDDocument,
+      methods: Vector[VerificationMethodOrRef]
+  ): Vector[VerificationMethod] = {
+    val (referenced, embedded) = methods.partitionMap[String, VerificationMethod] {
+      case uri: String            => Left(uri)
+      case pk: VerificationMethod => Right(pk)
+    }
+    val keySet = referenced.toSet
+    embedded ++ didDocument.verificationMethod.filter(pk => keySet.contains(pk.id))
   }
 
   // TODO Implement other key types


### PR DESCRIPTION
### Description: 
- add the right kid parameter to the jwt header in the proof object of the CredentialRequest of the OID4VCI flow ([ATL-6803](https://input-output.atlassian.net/browse/ATL-6803)

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
