### PR TITLE
ci: refactor auto-merge flow to use GitHub script and don't block the CI [skip ci]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -16,9 +16,6 @@ jobs:
     continue-on-error: true
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
       - name: Update PRs
         uses: actions/github-script@v7
         continue-on-error: true

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,6 +8,7 @@ on:
     types: [opened, synchronize, reopened, labeled, ready_for_review]
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   update-pull-requests:

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,5 +1,4 @@
 name: Auto Merge Main into Feature Branch
-
 on:
   push:
     branches:
@@ -8,56 +7,97 @@ on:
     types: [opened, synchronize, reopened, labeled, ready_for_review]
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
-  update-pull-requests:
-    if: contains(github.event.pull_request.labels.*.name, 'autoupdate')
+  on-pull-request:
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'autoupdate')
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
       - name: Update PRs
         uses: actions/github-script@v7
-        continue-on-error: true
         with:
           script: |
-            async function updatePullRequest(pr) {
-              const { data: changes } = await github.rest.repos.compareCommitsWithBasehead({
-                ...context.repo,
-                basehead: `${pr.head.ref}...${pr.base.ref}`
-              });
-              if (changes.status === 'behind') {
-                console.info(`PR #${pr.number}: No changes detected`);
-              } else {
-                console.info(`PR #${pr.number}: Changes detected`);
-                const { status: updateStatus } = await github.rest.pulls.updateBranch({
+            let pr = {
+              number: ${{ github.event.pull_request.number }},
+              head: {
+                sha: "${{ github.event.pull_request.head.sha }}",
+                ref:"${{ github.event.pull_request.head.ref }}"
+              },
+              base: {
+                ref: "${{ github.event.pull_request.base.ref }}"
+              }
+            }
+            let changes = await github.rest.repos.compareCommitsWithBasehead({
+              ...context.repo,
+              basehead: `${pr.head.ref}...${pr.base.ref}`
+            });
+            // after merging main to PR the comparison becomes 'behind'
+            if (changes.data.status == 'behind') {
+              console.info("no changes detected")
+            } else {
+              console.info("changes detected")
+              let updateResult = await github.rest.pulls.updateBranch({
                   ...context.repo,
                   expected_head_sha: pr.head.sha,
                   pull_number: pr.number,
-                });
-                const commentMessage = updateStatus === 202 ? ":rocket: Merge success!" : ":bangbang: Merge failed!";
-                await github.rest.issues.createComment({
+              });
+              let commentMessage = updateResult.status == 202 ? ":rocket: Merge success!" : ":bangbang: Merge failed!"
+              let commentResult = await github.rest.issues.createComment({
                   ...context.repo,
                   issue_number: pr.number,
-                  body: commentMessage,
-                });
-              }
+                  body: commentMessage
+              });
             }
+  on-main-push:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
 
-            if (github.event_name === 'pull_request') {
-              const pr = github.event.pull_request;
-              await updatePullRequest(pr);
-            } else if (github.event_name === 'push') {
-              const { data: pullRequests } = await github.rest.pulls.list({
+    steps:
+      - name: Update PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pullRequests } = await github.rest.pulls.list({
                 base: 'main',
                 sort: 'updated',
                 state: 'open',
                 ...context.repo
-              });
-              const labeledPullRequests = pullRequests.filter(pr => pr.labels.some(label => label.name === 'autoupdate'));
-              for (const pr of labeledPullRequests) {
-                console.info(`Checking pull request #${pr.number}`);
-                await updatePullRequest(pr);
-              }
+            })
+            const labeledPullRequests = pullRequests.filter(pr => pr.labels.filter(label => label.name == 'autoupdate').length > 0)
+            for (let pr of labeledPullRequests) {
+                console.info("Check pull request number [" + `${pr.number}` + "]")
+                console.info("  -", "title:", pr.title)
+                console.info("  -", "url:", pr.html_url)
+                try {
+                    let changes = await github.rest.repos.compareCommits({
+                        ...context.repo,
+                        base: pr.head.ref,
+                        head: pr.base.ref
+                    });
+                    // after merging main to PR the comparison becomes 'behind'
+                    if (changes.data.status == 'behind') {
+                        console.info("  -", "comparison to main:", "no changes detected")
+                        console.info()
+                        continue
+                    }
+                    console.info("  -", "comparison to main:", "changes detected")
+                    // merge main to pull request
+                    let updateResult = await github.rest.pulls.updateBranch({
+                        ...context.repo,
+                        expected_head_sha: pr.head.sha,
+                        pull_number: pr.number,
+                    });
+                    // comment on pull request
+                    let commentMessage = updateResult.status == 202 ? ":rocket: Merge success" : ":bangbang: Merge failed"
+                    let commentResult = await github.rest.issues.createComment({
+                        ...context.repo,
+                        issue_number: pr.number,
+                        body: commentMessage
+                    });
+                    console.info("  - comment created", commentResult.status == 201 ? "successfully" : "unsuccessfully")
+                    console.info()
+                } catch (err) {
+                    core.error(err);
+                }
             }

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,79 +1,65 @@
 name: Auto Merge Main into Feature Branch
 
-# Automatically merge main into a feature branch when a pull request is labeled with 'autoupdate'
-
 on:
+  push:
+    branches:
+      - main
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, labeled, ready_for_review]
+    branches:
+      - main
 
 jobs:
-  auto-merge:
+  update-pull-requests:
     if: contains(github.event.pull_request.labels.*.name, 'autoupdate')
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: main
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-      - name: Set up GPG key to extract the Git configuration
-        uses: crazy-max/ghaction-import-gpg@v3
-        id: import_gpg
-        with:
-          gpg-private-key: ${{ secrets.HYP_BOT_GPG_PRIVATE }}
-          passphrase: ${{ secrets.HYP_BOT_GPG_PASSWORD }}
-          git-user-signingkey: true
-          git-commit-gpgsign: true
-          git_config_global: true
-          git_tag_gpgsign: true
-
-      - name: Set up Git
-        run: |
-          git config --global user.name '${{ steps.import_gpg.outputs.name }}'
-          git config --global user.email '${{ steps.import_gpg.outputs.email }}'
-
-      - name: Fetch all branches
-        run: git fetch origin
-
-      - name: Checkout the feature branch
-        run: git checkout ${{ github.event.pull_request.head.ref }}
-
-      - name: Merge main into feature branch
-        run: git merge --squash origin/main
-
-      - name: Commit changes
-        run: git commit -S -s -m "Merge main into ${{ github.event.pull_request.head.ref }}"
-        if: success()
-
-      - name: Push changes
-        run: git push origin ${{ github.event.pull_request.head.ref }}
-        if: success()
-
-      - name: Add comment to PR
-        if: success()
+      - name: Update PRs
         uses: actions/github-script@v7
+        continue-on-error: true
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const prNumber = ${{ github.event.pull_request.number }};
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body: 'The main branch has been successfully merged into this feature branch! :rocket:'
-            });
+            async function updatePullRequest(pr) {
+              const { data: changes } = await github.rest.repos.compareCommitsWithBasehead({
+                ...context.repo,
+                basehead: `${pr.head.ref}...${pr.base.ref}`
+              });
+              if (changes.status === 'behind') {
+                console.info(`PR #${pr.number}: No changes detected`);
+              } else {
+                console.info(`PR #${pr.number}: Changes detected`);
+                const { status: updateStatus } = await github.rest.pulls.updateBranch({
+                  ...context.repo,
+                  expected_head_sha: pr.head.sha,
+                  pull_number: pr.number,
+                });
+                const commentMessage = updateStatus === 202 ? ":rocket: Merge success!" : ":bangbang: Merge failed!";
+                await github.rest.issues.createComment({
+                  ...context.repo,
+                  issue_number: pr.number,
+                  body: commentMessage,
+                });
+              }
+            }
 
-      - name: Add sad comment to PR
-        if: failure()
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const prNumber = ${{ github.event.pull_request.number }};
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body: 'The main branch cannot be merged into the feature branch without your help :cry:'
-            });
+            if (github.event_name === 'pull_request') {
+              const pr = github.event.pull_request;
+              await updatePullRequest(pr);
+            } else if (github.event_name === 'push') {
+              const { data: pullRequests } = await github.rest.pulls.list({
+                base: 'main',
+                sort: 'updated',
+                state: 'open',
+                ...context.repo
+              });
+              const labeledPullRequests = pullRequests.filter(pr => pr.labels.some(label => label.name === 'autoupdate'));
+              for (const pr of labeledPullRequests) {
+                console.info(`Checking pull request #${pr.number}`);
+                await updatePullRequest(pr);
+              }
+            }


### PR DESCRIPTION
### Description: 
- rewrite the script that is able to automatically merge the main branch into the feature branch

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
