### PR TITLE
fix: add reportProcessingFailure back in PresentationRepository

### DIFF
--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/repository/PresentationRepository.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/repository/PresentationRepository.scala
@@ -74,5 +74,5 @@ trait PresentationRepository {
   def updateAfterFail(
       recordId: DidCommID,
       failReason: Option[Failure]
-  ): URIO[WalletAccessContext, Unit]
+  ): UIO[Unit]
 }

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationService.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationService.scala
@@ -169,6 +169,6 @@ trait PresentationService {
   def reportProcessingFailure(
       recordId: DidCommID,
       failReason: Option[Failure]
-  ): ZIO[WalletAccessContext, PresentationError, Unit]
+  ): IO[PresentationError, Unit]
 
 }

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceImpl.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceImpl.scala
@@ -1098,14 +1098,11 @@ private class PresentationServiceImpl(
     } yield result
   }
 
-  def reportProcessingFailure(
+  override def reportProcessingFailure(
       recordId: DidCommID,
       failReason: Option[Failure]
-  ): ZIO[WalletAccessContext, PresentationError, Unit] =
-    for {
-      _ <- getRecord(recordId)
-      result <- presentationRepository.updateAfterFail(recordId, failReason)
-    } yield result
+  ): IO[PresentationError, Unit] =
+    presentationRepository.updateAfterFail(recordId, failReason)
 
   private def getRecordFromThreadId(
       thid: DidCommID

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceNotifier.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceNotifier.scala
@@ -281,7 +281,7 @@ class PresentationServiceNotifier(
   override def reportProcessingFailure(
       recordId: DidCommID,
       failReason: Option[Failure]
-  ): ZIO[WalletAccessContext, PresentationError, Unit] = svc.reportProcessingFailure(recordId, failReason)
+  ): IO[PresentationError, Unit] = svc.reportProcessingFailure(recordId, failReason)
 }
 
 object PresentationServiceNotifier {

--- a/pollux/sql-doobie/src/main/scala/org/hyperledger/identus/pollux/sql/repository/JdbcCredentialRepository.scala
+++ b/pollux/sql-doobie/src/main/scala/org/hyperledger/identus/pollux/sql/repository/JdbcCredentialRepository.scala
@@ -548,7 +548,7 @@ class JdbcCredentialRepository(xa: Transactor[ContextAwareTask], xb: Transactor[
       .ensureOneAffectedRowOrDie
   }
 
-  def updateAfterFail(
+  override def updateAfterFail(
       recordId: DidCommID,
       failReason: Option[Failure]
   ): URIO[WalletAccessContext, Unit] = {

--- a/pollux/sql-doobie/src/main/scala/org/hyperledger/identus/pollux/sql/repository/JdbcPresentationRepository.scala
+++ b/pollux/sql-doobie/src/main/scala/org/hyperledger/identus/pollux/sql/repository/JdbcPresentationRepository.scala
@@ -489,10 +489,10 @@ class JdbcPresentationRepository(
       .ensureOneAffectedRowOrDie
   }
 
-  def updateAfterFail(
+  override def updateAfterFail(
       recordId: DidCommID,
       failReason: Option[Failure]
-  ): URIO[WalletAccessContext, Unit] = {
+  ): UIO[Unit] = {
     val cxnIO = sql"""
         | UPDATE public.presentation_records
         | SET
@@ -503,7 +503,7 @@ class JdbcPresentationRepository(
         |   id = $recordId
         """.stripMargin.update
     cxnIO.run
-      .transactWallet(xa)
+      .transact(xb)
       .orDie
       .ensureOneAffectedRowOrDie
   }


### PR DESCRIPTION
### Description: 
Add reportProcessingFailure back in PresentationRepository

Fix: this was removed recently in another PR 
Work for ATL-6932 and ATL-7329

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
