### PR TITLE
fix: avoid name and operationId conflict when creating oas client

### DIFF
--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/CredentialIssuerEndpoints.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/CredentialIssuerEndpoints.scala
@@ -77,7 +77,7 @@ object CredentialIssuerEndpoints {
     )
     .out(jsonBody[CredentialResponse])
     .errorOut(credentialEndpointErrorOutput)
-    .name("issueCredential")
+    .name("oid4vciIssueCredential")
     .summary("Credential Endpoint")
     .description(
       """OID for VCI [Credential Endpoint](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-endpoint)""".stripMargin
@@ -97,7 +97,7 @@ object CredentialIssuerEndpoints {
     )
     .out(jsonBody[CredentialOfferResponse])
     .errorOut(EndpointOutputs.basicFailureAndNotFoundAndForbidden)
-    .name("createCredentialOffer")
+    .name("oid4vciCreateCredentialOffer")
     .summary("Create a new credential offer")
     .description(
       """Create a new credential offer and return a compliant `CredentialOffer` for the holder's

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/http/CredentialErrorResponse.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/http/CredentialErrorResponse.scala
@@ -14,7 +14,11 @@ import scala.util.Try
 type ExtendedErrorResponse = ErrorResponse | CredentialErrorResponse
 
 object ExtendedErrorResponse {
-  given schema: Schema[ExtendedErrorResponse] = Schema.schemaForEither[ErrorResponse, CredentialErrorResponse].as
+  given schema: Schema[ExtendedErrorResponse] =
+    Schema
+      .schemaForEither[ErrorResponse, CredentialErrorResponse]
+      .name(Schema.SName("ExtendedErrorResponse"))
+      .as
   given encoder: JsonEncoder[ExtendedErrorResponse] =
     ErrorResponse.encoder
       .orElseEither(CredentialErrorResponse.encoder)


### PR DESCRIPTION
### Description: 

This fix some issues when generating OAS client as it fails some validation. New client release is required for new oid4vci test scenarios.

### Alternatives Considered (optional): 
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
