### PR TITLE
build: make sure -Dquill.macro.log=false is passed when quill compiles

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,1 @@
+-Dquill.macro.log=false

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,6 @@ inThisBuild(
       "-feature",
       "-deprecation",
       "-unchecked",
-      "-Dquill.macro.log=false", // disable quill macro logs
       "-Wunused:all",
       "-Wconf:any:warning", // TODO: change unused imports to errors, Wconf configuration string is different from scala 2, figure out how!
       // TODO "-feature",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.0
+sbt.version=1.10.1


### PR DESCRIPTION
### Description: 

This PR make sure quill pick up the `quill.macro.log=false` flag. This remove a all of static query logs. However this does not make the log of `Dynamic Query Detected ...` logs disappeared. It would require a change in the [library here](https://github.com/zio/zio-protoquill/blob/49a4351751bae2cf764e7360429f611c1a159164/quill-sql/src/main/scala/io/getquill/context/StaticTranslationMacro.scala#L299).

### Alternatives Considered (optional): 
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
