### PR TITLE
ci: do not use default token for autoupdate CI job [skip ci]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Update PRs
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.IDENTUS_CI }}
           script: |
             let pr = {
               number: ${{ github.event.pull_request.number }},
@@ -57,6 +58,7 @@ jobs:
       - name: Update PRs
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.IDENTUS_CI }}
           script: |
             const { data: pullRequests } = await github.rest.pulls.list({
                 base: 'main',


### PR DESCRIPTION
### Description: 

Any PR with `autoupdate` label gets the merge from `main` but the default `GITHUB_TOKEN` [will not trigger another workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow).

However, this requires `IDENTUS_CI` to have these permissions

![Screenshot_2024-07-19_16-32-21](https://github.com/user-attachments/assets/fb362e1c-0e8c-48d6-b24b-67623f42a532)


### Alternatives Considered (optional): 
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
