### PR TITLE
fix: changed IO to UIO as as underline repository doesn't throw error

### DIFF
--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/jobs/PresentBackgroundJobs.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/jobs/PresentBackgroundJobs.scala
@@ -85,9 +85,6 @@ object PresentBackgroundJobs extends BackgroundJobsHelper {
           ZIO
             .service[PresentationService]
             .flatMap(_.reportProcessingFailure(record.id, Some(ex)))
-            .catchAll(ex =>
-              ZIO.logErrorCause(s"PresentBackgroundJobs - Fail to recover from ${record.id}", Cause.fail(ex))
-            )
         case ex => ZIO.logErrorCause(s"PresentBackgroundJobs - Error processing record: ${record.id}", Cause.fail(ex))
       }
       .catchAllDefect(d =>

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationService.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationService.scala
@@ -169,6 +169,6 @@ trait PresentationService {
   def reportProcessingFailure(
       recordId: DidCommID,
       failReason: Option[Failure]
-  ): IO[PresentationError, Unit]
+  ): UIO[Unit]
 
 }

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceImpl.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceImpl.scala
@@ -1101,7 +1101,7 @@ private class PresentationServiceImpl(
   override def reportProcessingFailure(
       recordId: DidCommID,
       failReason: Option[Failure]
-  ): IO[PresentationError, Unit] =
+  ): UIO[Unit] =
     presentationRepository.updateAfterFail(recordId, failReason)
 
   private def getRecordFromThreadId(

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceNotifier.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceNotifier.scala
@@ -2,12 +2,7 @@ package org.hyperledger.identus.pollux.core.service
 
 import org.hyperledger.identus.event.notification.{Event, EventNotificationService}
 import org.hyperledger.identus.mercury.model.DidId
-import org.hyperledger.identus.mercury.protocol.presentproof.{
-  Presentation,
-  ProofType,
-  ProposePresentation,
-  RequestPresentation
-}
+import org.hyperledger.identus.mercury.protocol.presentproof.{Presentation, ProofType, ProposePresentation, RequestPresentation}
 import org.hyperledger.identus.pollux.anoncreds.AnoncredPresentation
 import org.hyperledger.identus.pollux.core.model.{DidCommID, PresentationRecord}
 import org.hyperledger.identus.pollux.core.model.error.PresentationError
@@ -16,7 +11,7 @@ import org.hyperledger.identus.pollux.core.service.serdes.{AnoncredCredentialPro
 import org.hyperledger.identus.pollux.sdjwt.{HolderPrivateKey, PresentationCompact}
 import org.hyperledger.identus.pollux.vc.jwt.{Issuer, PresentationPayload, W3cCredentialPayload}
 import org.hyperledger.identus.shared.models.*
-import zio.{IO, URLayer, ZIO, ZLayer}
+import zio.{IO, UIO, URLayer, ZIO, ZLayer}
 import zio.json.*
 
 import java.time.Instant
@@ -281,7 +276,7 @@ class PresentationServiceNotifier(
   override def reportProcessingFailure(
       recordId: DidCommID,
       failReason: Option[Failure]
-  ): IO[PresentationError, Unit] = svc.reportProcessingFailure(recordId, failReason)
+  ): UIO[Unit] = svc.reportProcessingFailure(recordId, failReason)
 }
 
 object PresentationServiceNotifier {

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceNotifier.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceNotifier.scala
@@ -2,7 +2,12 @@ package org.hyperledger.identus.pollux.core.service
 
 import org.hyperledger.identus.event.notification.{Event, EventNotificationService}
 import org.hyperledger.identus.mercury.model.DidId
-import org.hyperledger.identus.mercury.protocol.presentproof.{Presentation, ProofType, ProposePresentation, RequestPresentation}
+import org.hyperledger.identus.mercury.protocol.presentproof.{
+  Presentation,
+  ProofType,
+  ProposePresentation,
+  RequestPresentation
+}
 import org.hyperledger.identus.pollux.anoncreds.AnoncredPresentation
 import org.hyperledger.identus.pollux.core.model.{DidCommID, PresentationRecord}
 import org.hyperledger.identus.pollux.core.model.error.PresentationError

--- a/pollux/core/src/test/scala/org/hyperledger/identus/pollux/core/repository/PresentationRepositorySpecSuite.scala
+++ b/pollux/core/src/test/scala/org/hyperledger/identus/pollux/core/repository/PresentationRepositorySpecSuite.scala
@@ -427,7 +427,7 @@ object PresentationRepositorySpecSuite {
         exit <- repo.updatePresentationWithCredentialsToUse(record2.id, Option(Nil), newState).provide(wallet2).exit
       } yield assert(exit)(dies(hasMessage(equalTo("Unexpected affected row count: 0"))))
     },
-    test("unable to updateAfterFail PresentationRecord outside of the wallet") {
+    test("updateAfterFail PresentationRecord outside of the wallet") {
       val walletId1 = WalletId.random
       val walletId2 = WalletId.random
       val wallet1 = ZLayer.succeed(WalletAccessContext(walletId1))
@@ -442,7 +442,6 @@ object PresentationRepositorySpecSuite {
             record2.id,
             Some(FailureInfo("PresentationRepositorySpecSuite", StatusCode(999), "fail reason"))
           )
-          .provide(wallet2)
           .exit
       } yield assert(exit)(dies(hasMessage(equalTo("Unexpected affected row count: 0"))))
     },

--- a/pollux/core/src/test/scala/org/hyperledger/identus/pollux/core/service/MockPresentationService.scala
+++ b/pollux/core/src/test/scala/org/hyperledger/identus/pollux/core/service/MockPresentationService.scala
@@ -19,6 +19,7 @@ import zio.{mock, IO, URLayer, ZIO, ZLayer}
 import zio.json.*
 import zio.mock.{Mock, Proxy}
 import zio.UIO
+
 import java.time.Instant
 import java.util.UUID
 

--- a/pollux/core/src/test/scala/org/hyperledger/identus/pollux/core/service/MockPresentationService.scala
+++ b/pollux/core/src/test/scala/org/hyperledger/identus/pollux/core/service/MockPresentationService.scala
@@ -18,7 +18,7 @@ import org.hyperledger.identus.shared.models.*
 import zio.{mock, IO, URLayer, ZIO, ZLayer}
 import zio.json.*
 import zio.mock.{Mock, Proxy}
-
+import zio.UIO
 import java.time.Instant
 import java.util.UUID
 
@@ -262,7 +262,7 @@ object MockPresentationService extends Mock[PresentationService] {
       override def reportProcessingFailure(
           recordId: DidCommID,
           failReason: Option[Failure]
-      ): IO[PresentationError, Unit] = ???
+      ): UIO[Unit] = ???
 
     }
   }


### PR DESCRIPTION
### Description: 
PresentationRepository update updateAfterFail doesn't throw error, Chnaged IO to UIO


### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
