### PR TITLE
ci: use IDENTUS_CI2 token for automerge [skip ci]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Update PRs
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.IDENTUS_CI }}
+          github-token: ${{ secrets.TMP_IDENTUS_CI2 }}
           script: |
             let pr = {
               number: ${{ github.event.pull_request.number }},
@@ -58,7 +58,7 @@ jobs:
       - name: Update PRs
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.IDENTUS_CI }}
+          github-token: ${{ secrets.TMP_IDENTUS_CI2 }}
           script: |
             const { data: pullRequests } = await github.rest.pulls.list({
                 base: 'main',


### PR DESCRIPTION
### Description: 

We don't have control over `IDENTUS_CI` token permissions. Now, switching back to our own token so we can grant the right permissions. Later we will ask `IDENTUS_CI` to be updated.

### Alternatives Considered (optional): 
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
