### PR TITLE
ci: make-revision-semver-compliant

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           VERSION=$(grep -Eo 'version := "[^"]+"' version.sbt | sed 's/version := "//; s/"//; s/-SNAPSHOT//')
           REVISION_VERSION=${VERSION}-${{ env.COMMIT_HASH }}
-          BUILD_VERSION=${REVISION_VERSION}-${{ env.BUILD_NUMBER }}
+          BUILD_VERSION=${{ env.BUILD_NUMBER }}-${REVISION_VERSION}
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
           echo "REVISION_VERSION=${REVISION_VERSION}" >> $GITHUB_ENV
           echo "BUILD_VERSION=${BUILD_VERSION}" >> $GITHUB_ENV


### PR DESCRIPTION
### Description: 
In this PR the BUILD_VERSION is changed to be PROJECT_VERSION-BUILD-NUMBER-COMMIT_SHA.
This change is required to add the possibility for the ArgoCD to track the latest version of the build.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
