### PR TITLE
ci: set next version properly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,6 @@ jobs:
           ref: ${{ github.event.inputs.release-branch }}
           fetch-depth: 0
 
-
       - name: Setup Java and Scala
         uses: olafurpg/setup-scala@v14
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       GITHUB_ACTOR: "hyperledger-bot"
       GITHUB_ACTOR_EMAIL: "hyperledger-bot@hyperledger.org"
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.IDENTUS_CI }}
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       # New JDK version makes 'localhost' lookup on linux return ipv6.
       # Our test containers are on ipv4. We need to make 'localhost' resolve to ipv4.
@@ -24,9 +24,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.IDENTUS_CI }}
+          ref: ${{ github.event.inputs.release-branch }}
           fetch-depth: 0
-          persist-credentials: false
+
 
       - name: Setup Java and Scala
         uses: olafurpg/setup-scala@v14
@@ -53,7 +54,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ env.GITHUB_ACTOR }}
-          password: ${{ env.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -2,13 +2,10 @@ export default {
     branches: [
         'main',
         '+([0-9])?(.{+([0-9]),x}).x',
-        { name: 'beta/*', prerelease: 'rc' }
+        { name: 'beta', prerelease: true }
     ],
     plugins: [
         '@semantic-release/commit-analyzer',
-        ["@semantic-release/exec", {
-            "prepareCmd": "docker buildx build --platform=linux/arm64,linux/amd64 --push -t ghcr.io/hyperledger/identus-cloud-agent:${nextRelease.version} ./cloud-agent/service/server/target/docker/stage"
-        }],
         ["@semantic-release/exec", {
             "prepareCmd": "echo ${nextRelease.version} > .release-version"
         }],
@@ -17,13 +14,16 @@ export default {
             "changelogFile": "CHANGELOG.md"
         }],
         ["@semantic-release/exec", {
-            "prepareCmd": "sbt \"release release-version ${nextRelease.version} next-version ${nextRelease.version}-SNAPSHOT with-defaults\""
+            "prepareCmd": "sbt \"release release-version ${nextRelease.version} with-defaults\""
         }],
         ["@semantic-release/exec", {
             "prepareCmd": "npm version ${nextRelease.version} --git-tag-version false"
         }],
         ["@semantic-release/exec", {
-            "prepareCmd": "sbt dumpLicenseReportAggregate && cp ./target/license-reports/root-licenses.md ./DEPENDENCIES.md"
+            "prepareCmd": 'sbt "set ThisBuild / version:=\\\"${nextRelease.version}\\\"" "dumpLicenseReportAggregate" && cp ./target/license-reports/root-licenses.md ./DEPENDENCIES.md'
+        }],
+        ["@semantic-release/exec", {
+            "prepareCmd": "docker buildx build --platform=linux/arm64,linux/amd64 --push -t ghcr.io/hyperledger/identus-cloud-agent:${nextRelease.version} ./cloud-agent/service/server/target/docker/stage"
         }],
         ["@semantic-release/exec", {
             "prepareCmd": "sed -i.bak \"s/AGENT_VERSION=.*/AGENT_VERSION=${nextRelease.version}/\" ./infrastructure/local/.env && rm -f ./infrastructure/local/.env.bak"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.38.0-SNAPSHOT"
+ThisBuild / version := "1.39.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.39.0-SNAPSHOT"
+ThisBuild / version := "1.38.0-SNAPSHOT"


### PR DESCRIPTION
### Description: 
In this PR, the release configuration is fixed to set the next version of the project higher after release.
The docker build step is moved to the right location
The generation of the DEPENDENCIES.md file with contain the same release version

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
