### PR TITLE
fix: operation id repeated error

### DIFF
--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/issue/controller/IssueEndpoints.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/issue/controller/IssueEndpoints.scala
@@ -91,12 +91,15 @@ object IssueEndpoints {
           .description("The credential issuance record was created successfully, and is returned in the response body.")
       )
       .out(jsonBody[IssueCredentialRecord].description("The issue credential record."))
-      .name("createCredentialOffer")
-      .summary("As a credential issuer, create a new credential offer that will be sent to a holder Agent.")
+      .name("createCredentialOfferInvitation")
+      .summary(
+        "As a credential issuer, create a new credential offer Invitation that will be delivered as out-of-band to a peer Agent."
+      )
       .description("""
-        |Creates a new credential offer that will be delivered, through a previously established DIDComm connection, to a holder Agent.
-        |The subsequent credential offer message adheres to the [Issue Credential Protocol 3.0 - Offer Credential](https://github.com/decentralized-identity/waci-didcomm/tree/main/issue_credential#offer-credential) specification.
-        |The created offer can be of two types: 'JWT' or 'AnonCreds'.
+        |Creates a new credential offer invitation to be delivered as an out-of-band message. 
+        |The invitation message adheres to the OOB specification as outlined [here](https://identity.foundation/didcomm-messaging/spec/#invitation),
+        |with the credential offer message attached according to the [Issue Credential Protocol 3.0 - Offer Credential specification](https://github.com/decentralized-identity/waci-didcomm/tree/main/issue_credential#offer-credential).
+        |The created offer attachment can be of three types: 'JWT', 'AnonCreds', or 'SDJWT'.
         |""".stripMargin)
       .tag(tagName)
 


### PR DESCRIPTION
### Description: 
fix for the issue when publishing cloud agent client
https://github.com/hyperledger/identus-cloud-agent/actions/runs/10600696602/job/29379084131


### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
