### PR TITLE
fix: remove `prism-agent` path from the apisixroute.yaml

### DIFF
--- a/infrastructure/charts/agent/templates/apisixroute.yaml
+++ b/infrastructure/charts/agent/templates/apisixroute.yaml
@@ -15,7 +15,6 @@ spec:
         - {{ . }}
       {{- end }}
       paths:
-      - /prism-agent/*
       - /{{ include "cloud-agent.name" . }}/*
     backends:
        - serviceName: agent-server-tapir-service
@@ -27,7 +26,7 @@ spec:
     - name: proxy-rewrite
       enable: true
       config:
-        regex_uri: ["^/(prism-agent|{{ include "cloud-agent.name" . }})/(.*)","/$2"]
+        regex_uri: ["^/({{ include "cloud-agent.name" . }})/(.*)","/$2"]
     - name: uri-blocker
       enable: true
       config:
@@ -56,7 +55,6 @@ spec:
         - {{ . }}
       {{- end }}
       paths:
-      - /prism-agent/didcomm*
       - /{{ include "cloud-agent.name" . }}/didcomm*
     backends:
       - serviceName: agent-server-didcomm-service
@@ -65,7 +63,7 @@ spec:
     - name: proxy-rewrite
       enable: true
       config:
-        regex_uri: ["^/(prism-agent|{{ include "cloud-agent.name" . }})/didcomm(.*)", "/$2"]
+        regex_uri: ["^/({{ include "cloud-agent.name" . }})/didcomm(.*)", "/$2"]
     {{- template "cors" . }}
     {{- template "headers.requestId" . }}
     {{- template "headers.security" . }}
@@ -88,7 +86,6 @@ spec:
         - {{ . }}
       {{- end }}
       paths:
-      - /prism-agent/schema-registry/schemas/*
       - /{{ include "cloud-agent.name" . }}/schema-registry/schemas/*
       methods:
       - GET
@@ -99,7 +96,7 @@ spec:
     - name: proxy-rewrite
       enable: true
       config:
-        regex_uri: ["^/(prism-agent|{{ include "cloud-agent.name" . }})/schema-registry/schemas/(.*)", "/schema-registry/schemas/$2"]
+        regex_uri: ["^/({{ include "cloud-agent.name" . }})/schema-registry/schemas/(.*)", "/schema-registry/schemas/$2"]
     {{- template "cors" . }}
     {{- template "headers.requestId" . }}
     {{- template "headers.security" . }}
@@ -122,7 +119,6 @@ spec:
       - {{ . }}
       {{- end }}
       paths:
-        - /prism-agent/credential-definition-registry/definitions/*
         - /{{ include "cloud-agent.name" . }}/credential-definition-registry/definitions/*
       methods:
         - GET
@@ -133,7 +129,7 @@ spec:
     - name: proxy-rewrite
       enable: true
       config:
-        regex_uri: ["^/(prism-agent|{{ include "cloud-agent.name" . }})/credential-definition-registry/definitions/(.*)", "/credential-definition-registry/definitions/$2"]
+        regex_uri: ["^/({{ include "cloud-agent.name" . }})/credential-definition-registry/definitions/(.*)", "/credential-definition-registry/definitions/$2"]
     {{- template "cors" . }}
     {{- template "headers.requestId" . }}
     {{- template "headers.security" . }}
@@ -156,7 +152,6 @@ spec:
         - {{ . }}
       {{- end }}
       paths:
-      - /prism-agent/docs/*
       - /{{ include "cloud-agent.name" . }}/docs/*
     backends:
       - serviceName: agent-server-tapir-service
@@ -165,7 +160,7 @@ spec:
     - name: proxy-rewrite
       enable: true
       config:
-        regex_uri: ["^/(prism-agent|{{ include "cloud-agent.name" . }})/docs/(.*)","/docs/$2"]
+        regex_uri: ["^/({{ include "cloud-agent.name" . }})/docs/(.*)","/docs/$2"]
     {{- template "cors" . }}
     {{- template "headers.requestId" . }}
     {{- template "headers.security" . }}


### PR DESCRIPTION
### Description: 
It's a polishing of the helm chart configuration for the cloud-agent and APISIX in the scope of renaming from `prism-agent` to the `cloud-agent`
It's expected that this change will fix the issue in the SIT environment

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
