### PR TITLE
ci: disable scalafmt run in the Scala Steward PRs [skip ci]

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -26,3 +26,6 @@ updates.limit = 5
 # Supported variables: ${artifactName}, ${currentVersion}, ${nextVersion} and ${default}
 # Default: "${default}" which is equivalent to "Update ${artifactName} to ${nextVersion}"
 commits.message = "${default}\n\nSigned-off-by: Hyperledger Bot <hyperledger-bot@hyperledger.org>"
+
+# For some reason, Scala Steward reformat the code in a weird way. This configurion is set to disable it.
+scalafmt.runAfterUpgrading = false


### PR DESCRIPTION
### Description: 
Disable the run of scalafmt in the Scala Steward PRs

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
