### PR TITLE
ci: skip renaming of OpenAPI specification when the release is made from the tag

### DIFF
--- a/.github/workflows/release-clients.yml
+++ b/.github/workflows/release-clients.yml
@@ -87,6 +87,7 @@ jobs:
           path: ./cloud-agent/service/api/http
 
       - name: Rename OpenAPI specification
+        if: ${{ !inputs.releaseTag }}
         working-directory: cloud-agent/service/api/http
         run: |
           mv cloud-agent-openapi-spec-${{ inputs.revision }}.yaml cloud-agent-openapi-spec.yaml


### PR DESCRIPTION
### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
