### PR TITLE
fix: return 404 when create credConfig on non-existing issuer

### DIFF
--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/OID4VCIIssuerMetadataService.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/OID4VCIIssuerMetadataService.scala
@@ -67,7 +67,7 @@ trait OID4VCIIssuerMetadataService {
       format: CredentialFormat,
       configurationId: String,
       schemaId: String
-  ): ZIO[WalletAccessContext, InvalidSchemaId | UnsupportedCredentialFormat, CredentialConfiguration]
+  ): ZIO[WalletAccessContext, InvalidSchemaId | UnsupportedCredentialFormat | IssuerIdNotFound, CredentialConfiguration]
   def getCredentialConfigurations(
       issuerId: UUID
   ): IO[IssuerIdNotFound, Seq[CredentialConfiguration]]
@@ -127,8 +127,13 @@ class OID4VCIIssuerMetadataServiceImpl(repository: OID4VCIIssuerMetadataReposito
       format: CredentialFormat,
       configurationId: String,
       schemaId: String
-  ): ZIO[WalletAccessContext, InvalidSchemaId | UnsupportedCredentialFormat, CredentialConfiguration] = {
+  ): ZIO[
+    WalletAccessContext,
+    InvalidSchemaId | UnsupportedCredentialFormat | IssuerIdNotFound,
+    CredentialConfiguration
+  ] = {
     for {
+      _ <- getCredentialIssuer(issuerId)
       _ <- format match {
         case CredentialFormat.JWT => ZIO.unit
         case f                    => ZIO.fail(UnsupportedCredentialFormat(f))


### PR DESCRIPTION
ATL-7837

Return 404 response instead of 500 when create oid4vci credential-configurations for non-existing issuer.