### PR TITLE
chore: rely on Tapir's default value for OpenAPI spec version

### DIFF
--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/http/DocModels.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/http/DocModels.scala
@@ -55,7 +55,6 @@ object DocModels {
 
   val customiseDocsModel: OpenAPI => OpenAPI = { oapi =>
     oapi
-      .openapi("3.0.3")
       .info(
         Info(
           title = "Identus Cloud Agent API Reference",


### PR DESCRIPTION
Rely on Tapir's default value for OpenAPI spec version