### PR TITLE
chore: fix generated OAS version to 3.0.3 as TS generator fails with 3.1.0

### DIFF
--- a/cloud-agent/service/server/src/test/scala/org/hyperledger/identus/api/util/Tapir2StaticOAS.scala
+++ b/cloud-agent/service/server/src/test/scala/org/hyperledger/identus/api/util/Tapir2StaticOAS.scala
@@ -41,7 +41,7 @@ object Tapir2StaticOAS extends ZIOAppDefault {
     } yield {
       import sttp.apispec.openapi.circe.yaml.*
       val model = DocModels.customiseDocsModel(OpenAPIDocsInterpreter().toOpenAPI(allEndpoints.map(_.endpoint), "", ""))
-      val yaml = model.info(model.info.copy(version = args(1))).toYaml
+      val yaml = model.info(model.info.copy(version = args(1))).toYaml3_0_3
       val path = Path.of(args.head)
       Using(Files.newBufferedWriter(path, StandardCharsets.UTF_8)) { writer => writer.write(yaml) }
     }


### PR DESCRIPTION
Fix generated OAS version to 3.0.3 as TS generator fails with 3.1.0