### PR TITLE
fix: Warning on Invitation generated  on Issuance

### DIFF
--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/jobs/IssueBackgroundJobs.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/jobs/IssueBackgroundJobs.scala
@@ -160,6 +160,33 @@ object IssueBackgroundJobs extends BackgroundJobsHelper {
     val exchange = for {
       _ <- ZIO.logDebug(s"Running action with records => $record")
       _ <- record match {
+        case IssueCredentialRecord(
+              id,
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              Role.Issuer,
+              _,
+              _,
+              _,
+              _,
+              InvitationGenerated,
+              Some(offer),
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+              _,
+            ) =>
+          ZIO.debug(s" Connectionless InvitationGenerated record received no processing required") *> ZIO.unit
         // Offer should be sent from Issuer to Holder
         case IssueCredentialRecord(
               id,


### PR DESCRIPTION
### Description: 
Warning is generated in connection flow which is confusing it doesn't block the flow will be good address the unecessary noise
https://github.com/hyperledger/identus-cloud-agent/issues/1426

### Alternatives Considered (optional): 
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
