### PR TITLE
fix: mapping the claims attributes to json

### DIFF
--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/CredentialService.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/CredentialService.scala
@@ -215,7 +215,7 @@ object CredentialService {
           case Some("application/json") =>
             val jsonBytes = java.util.Base64.getUrlDecoder.decode(attr.value.getBytes(StandardCharsets.UTF_8))
             new String(jsonBytes, StandardCharsets.UTF_8).fromJson[Json] match
-              case Right(value) => ZIO.succeed(Json.Obj().add(attr.name, value))
+              case Right(value) => ZIO.succeed(jsonObject.add(attr.name, value))
               case Left(error)  => ZIO.fail(VCClaimsValueParsingError(error))
 
           case Some(media_type) =>

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/CredentialServiceImpl.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/CredentialServiceImpl.scala
@@ -1260,7 +1260,10 @@ class CredentialServiceImpl(
         .fromOption(record.offerCredentialData)
         .orElse(ZIO.dieMessage(s"Offer credential data not found in record: ${recordId.value}"))
       preview = offerCredentialData.body.credential_preview
+      _ = println(s"+++++++++++++++++++++$preview")
       claims <- CredentialService.convertAttributesToJsonClaims(preview.body.attributes).orDieAsUnmanagedFailure
+      _ = println(s"+++++++++++++++++++++$claims")
+
       jwtPresentation <- validateRequestCredentialDataProof(maybeOfferOptions, requestJwt)
         .tapError(error =>
           credentialRepository

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/CredentialServiceImpl.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/CredentialServiceImpl.scala
@@ -1260,10 +1260,7 @@ class CredentialServiceImpl(
         .fromOption(record.offerCredentialData)
         .orElse(ZIO.dieMessage(s"Offer credential data not found in record: ${recordId.value}"))
       preview = offerCredentialData.body.credential_preview
-      _ = println(s"+++++++++++++++++++++$preview")
       claims <- CredentialService.convertAttributesToJsonClaims(preview.body.attributes).orDieAsUnmanagedFailure
-      _ = println(s"+++++++++++++++++++++$claims")
-
       jwtPresentation <- validateRequestCredentialDataProof(maybeOfferOptions, requestJwt)
         .tapError(error =>
           credentialRepository


### PR DESCRIPTION
### Description: 
mapped the claim attributes correctly in to json

### Alternatives Considered (optional): 
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
