### PR TITLE
fix:  Add disclose claims to presentation record credential type SDJWT 

### DIFF
--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/jobs/PresentBackgroundJobs.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/jobs/PresentBackgroundJobs.scala
@@ -124,18 +124,19 @@ object PresentBackgroundJobs extends BackgroundJobsHelper {
               _,
               _,
               _,
+              _,
               _
             ) =>
           ZIO.unit
-        case PresentationRecord(_, _, _, _, _, _, _, InvitationExpired, _, _, _, _, _, _, _, _, _, _, _, _, _, _) =>
+        case PresentationRecord(_, _, _, _, _, _, _, InvitationExpired, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) =>
           ZIO.unit
-        case PresentationRecord(id, _, _, _, _, _, _, ProposalPending, _, _, _, _, _, _, _, _, _, _, _, _, _, _) =>
+        case PresentationRecord(id, _, _, _, _, _, _, ProposalPending, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) =>
           ZIO.fail(NotImplemented)
-        case PresentationRecord(id, _, _, _, _, _, _, ProposalSent, _, _, _, _, _, _, _, _, _, _, _, _, _, _) =>
+        case PresentationRecord(id, _, _, _, _, _, _, ProposalSent, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) =>
           ZIO.fail(NotImplemented)
-        case PresentationRecord(id, _, _, _, _, _, _, ProposalReceived, _, _, _, _, _, _, _, _, _, _, _, _, _, _) =>
+        case PresentationRecord(id, _, _, _, _, _, _, ProposalReceived, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) =>
           ZIO.fail(NotImplemented)
-        case PresentationRecord(id, _, _, _, _, _, _, ProposalRejected, _, _, _, _, _, _, _, _, _, _, _, _, _, _) =>
+        case PresentationRecord(id, _, _, _, _, _, _, ProposalRejected, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) =>
           ZIO.fail(NotImplemented)
         case PresentationRecord(
               id,
@@ -149,6 +150,7 @@ object PresentBackgroundJobs extends BackgroundJobsHelper {
               _,
               _,
               None,
+              _,
               _,
               _,
               _,
@@ -184,6 +186,7 @@ object PresentBackgroundJobs extends BackgroundJobsHelper {
               _,
               _,
               _,
+              _,
               _
             ) => // Verifier
           Verifier.handleRequestPending(id, requestPresentation)
@@ -196,6 +199,7 @@ object PresentBackgroundJobs extends BackgroundJobsHelper {
               _,
               _,
               RequestSent,
+              _,
               _,
               _,
               _,
@@ -234,6 +238,7 @@ object PresentBackgroundJobs extends BackgroundJobsHelper {
               _,
               _,
               _,
+              _,
               _
             ) => // Prover
           ZIO.logDebug("PresentationRecord: RequestReceived") *> ZIO.unit
@@ -246,6 +251,7 @@ object PresentBackgroundJobs extends BackgroundJobsHelper {
               _,
               _,
               RequestRejected,
+              _,
               _,
               _,
               _,
@@ -284,10 +290,11 @@ object PresentBackgroundJobs extends BackgroundJobsHelper {
               _,
               _,
               _,
+              _,
               _
             ) =>
           ZIO.fail(NotImplemented)
-        case PresentationRecord(id, _, _, _, _, _, _, ProblemReportSent, _, _, _, _, _, _, _, _, _, _, _, _, _, _) =>
+        case PresentationRecord(id, _, _, _, _, _, _, ProblemReportSent, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) =>
           ZIO.fail(NotImplemented)
         case PresentationRecord(
               id,
@@ -298,6 +305,7 @@ object PresentBackgroundJobs extends BackgroundJobsHelper {
               _,
               _,
               ProblemReportReceived,
+              _,
               _,
               _,
               _,
@@ -336,6 +344,7 @@ object PresentBackgroundJobs extends BackgroundJobsHelper {
               _,
               _,
               _,
+              _,
               _
             ) => // Prover
           ZIO.fail(InvalidState("PresentationRecord 'RequestPending' with no Record"))
@@ -357,6 +366,7 @@ object PresentBackgroundJobs extends BackgroundJobsHelper {
               credentialsToUse,
               _,
               maybeCredentialsToUseJson,
+              _,
               _,
               _,
               _,
@@ -394,6 +404,7 @@ object PresentBackgroundJobs extends BackgroundJobsHelper {
               _,
               _,
               _,
+              _,
               _
             ) => // Prover
           ZIO.fail(InvalidState("PresentationRecord in 'PresentationGenerated' with no Presentation"))
@@ -420,12 +431,13 @@ object PresentBackgroundJobs extends BackgroundJobsHelper {
               _,
               _,
               _,
+              _,
               _
             ) => // Prover
           ZIO.logDebug("PresentationRecord: PresentationGenerated") *> ZIO.unit
           Prover.handlePresentationGenerated(id, presentation)
 
-        case PresentationRecord(id, _, _, _, _, _, _, PresentationSent, _, _, _, _, _, _, _, _, _, _, _, _, _, _) =>
+        case PresentationRecord(id, _, _, _, _, _, _, PresentationSent, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) =>
           ZIO.logDebug("PresentationRecord: PresentationSent") *> ZIO.unit
         case PresentationRecord(
               id,
@@ -449,6 +461,7 @@ object PresentBackgroundJobs extends BackgroundJobsHelper {
               _,
               _,
               _,
+              _,
               _
             ) => // Verifier
           ZIO.fail(InvalidState("PresentationRecord in 'PresentationReceived' with no Presentation"))
@@ -464,6 +477,7 @@ object PresentBackgroundJobs extends BackgroundJobsHelper {
               _,
               _,
               None,
+              _,
               _,
               _,
               _,
@@ -499,6 +513,7 @@ object PresentBackgroundJobs extends BackgroundJobsHelper {
               _,
               _,
               _,
+              _,
               _
             ) => // Verifier
           ZIO.logDebug("PresentationRecord: PresentationReceived") *> ZIO.unit
@@ -513,6 +528,7 @@ object PresentBackgroundJobs extends BackgroundJobsHelper {
               _,
               _,
               PresentationVerificationFailed,
+              _,
               _,
               _,
               _,
@@ -551,6 +567,7 @@ object PresentBackgroundJobs extends BackgroundJobsHelper {
               _,
               _,
               _,
+              _,
               _
             ) =>
           ZIO.logDebug("PresentationRecord: PresentationVerifiedAccepted") *> ZIO.unit
@@ -576,6 +593,7 @@ object PresentBackgroundJobs extends BackgroundJobsHelper {
               _,
               _,
               _,
+              _,
               _
             ) =>
           ZIO.logDebug("PresentationRecord: PresentationVerified") *> ZIO.unit
@@ -588,6 +606,7 @@ object PresentBackgroundJobs extends BackgroundJobsHelper {
               _,
               _,
               PresentationRejected,
+              _,
               _,
               _,
               _,
@@ -1224,12 +1243,16 @@ object PresentBackgroundJobs extends BackgroundJobsHelper {
                 verifiedClaims.mapError(error => PresentationReceivedError(error.toString))
               case any => ZIO.fail(PresentationReceivedError("Only Base64 Supported"))
             }
+            service <- ZIO.service[PresentationService]
             _ <- credentialsClaimsValidationResult match
               case valid: SDJWT.Valid =>
                 ZIO.logInfo(s"CredentialsClaimsValidationResult: $valid")
+                val jsonObj = valid.asInstanceOf[SDJWT.ValidClaims].claims
+                service
+                  .updateWithSDJWTDisclosedClaims(id, jsonObj)
+                  .provideSomeLayer(ZLayer.succeed(walletAccessContext))
               case invalid: SDJWT.Invalid =>
                 ZIO.logError(s"CredentialsClaimsValidationResult: $invalid")
-            service <- ZIO.service[PresentationService]
             presReceivedToProcessedAspect = CustomMetricsAspect.endRecordingTime(
               s"${id}_present_proof_flow_verifier_presentation_received_to_verification_success_or_failure_ms_gauge",
               "present_proof_flow_verifier_presentation_received_to_verification_success_or_failure_ms_gauge"

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/presentproof/controller/http/PresentationStatusPage.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/presentproof/controller/http/PresentationStatusPage.scala
@@ -71,6 +71,7 @@ object PresentationStatusPage {
               status = "RequestSent",
               proofs = Seq.empty,
               data = Seq.empty,
+              disclosedClaims = None,
               requestData = Seq.empty,
               connectionId = Some("e0d81be9-47ca-4e0b-b8a7-325e8c3abc2f"),
               invitation = None,
@@ -82,6 +83,7 @@ object PresentationStatusPage {
               role = "Prover",
               status = "RequestReceived",
               proofs = Seq.empty,
+              disclosedClaims = None,
               requestData = Seq.empty,
               data = Seq.empty,
               metaRetries = 5
@@ -92,6 +94,7 @@ object PresentationStatusPage {
               role = "Prover",
               status = "PresentationPending",
               proofs = Seq.empty,
+              disclosedClaims = None,
               requestData = Seq.empty,
               data = Seq.empty,
               metaRetries = 5
@@ -102,6 +105,7 @@ object PresentationStatusPage {
               role = "Verifier",
               status = "PresentationVerified",
               proofs = Seq.empty,
+              disclosedClaims = None,
               requestData = Seq.empty,
               data = Seq(
                 "{\"claimsToDisclose\":{\"emailAddress\":{},\"givenName\":{}},\"presentation\":\"{\\\"protected\\\":\\\"eyJhbGciOiJFZERTQSJ9\\\",\\\"payload\\\":\\\"eyJfc2QiOlsiMGl4d0tIV0dzbzFvZThFR0hQd2tGYW9EZE1TRFQ3SmgyNkZGSm1ZbGRnRSIsIjQ4VlFXZS1tcjBibHMyOWpicHFKeDNxX2dYY0k5N3dHcEpsZnRoNXQwMGciLCI0Wk9xanFNZVNUVHRKQTNJRExsc3ZXN0dTNzRIemNxY3N2NVFoZk1valE4IiwiUjhGRE0ydXB1V09mNmVJMVA5ckNPdG12c3puVWFFYXpncVNuN0JfeTE0MCIsIlU5MmpfUHlpcHN2TERNQTlDaVRWbnl3bUFzYTM4S2lDWm5TeVhyUE5mNG8iLCJldFB1Mmc5ajdRd01rZ3g5VnpEX1RnNTNUV3UydVpadk1KeHRnNEJ1WGJBIiwidGV3RG1LWklNcS10bUNrMkpqZU0wajNYbU1aUUFLN01heENVNlF4dm9OMCJdLCJfc2RfYWxnIjoic2hhLTI1NiIsImlzcyI6ImRpZDpwcmlzbToxMmEzOWI1YWEwZTcxODI3ZmMxYzYwMjg1ZDVlZWJjMTk0Yjg2NzFhYTJmY2QxZDM2NDBkMGYwMTBlMzliZmVlIiwiaWF0IjoxNzE3NDEwMzgzLCJleHAiOjE3MjAwMDIzODN9\\\",\\\"signature\\\":\\\"953FfSRU_0Y2q0ERrFPzbXJ_hkF0YQe5efwESaZwtXDCn8aanD3MUstp3lzqGZkhvcWRdtCCpIxzhy0zgKwLBg\\\",\\\"disclosures\\\":[\\\"WyI0SHF6MDZCeG5fRlJMb2hWX2lWNXp3IiwgImdpdmVuTmFtZSIsICJBbGljZSJd\\\",\\\"WyJLUnNYYU01c3NXZTl4UEhqQnNjT213IiwgImVtYWlsQWRkcmVzcyIsICJhbGljZUB3b25kZXJsYW5kLmNvbSJd\\\"],\\\"kb_jwt\\\":null}\"}"
@@ -115,6 +119,7 @@ object PresentationStatusPage {
               role = "Verifier",
               status = "InvitationGenerated",
               proofs = Seq.empty,
+              disclosedClaims = None,
               data = Seq.empty,
               requestData = Seq.empty,
               connectionId = None,

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/model/PresentationRecord.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/model/PresentationRecord.scala
@@ -10,6 +10,7 @@ import java.time.Instant
 
 type AnoncredCredentialProofs = zio.json.ast.Json
 type SdJwtCredentialToDisclose = zio.json.ast.Json
+type SdJwtDisclosedClaims = zio.json.ast.Json
 
 final case class PresentationRecord(
     id: DidCommID,
@@ -30,6 +31,7 @@ final case class PresentationRecord(
     anoncredCredentialsToUse: Option[AnoncredCredentialProofs],
     sdJwtClaimsToUseJsonSchemaId: Option[String],
     sdJwtClaimsToDisclose: Option[SdJwtCredentialToDisclose],
+    sdJwtDisclosedClaims: Option[SdJwtDisclosedClaims],
     metaRetries: Int,
     metaNextRetry: Option[Instant],
     metaLastFailure: Option[Failure],
@@ -64,6 +66,7 @@ object PresentationRecord {
       anoncredCredentialsToUse: Option[AnoncredCredentialProofs],
       sdJwtClaimsToUseJsonSchemaId: Option[String],
       sdJwtClaimsToDisclose: Option[SdJwtCredentialToDisclose],
+      sdJwtDisclosedClaims: Option[SdJwtDisclosedClaims],
       metaRetries: Int,
       metaNextRetry: Option[Instant],
       metaLastFailure: Option[Failure]
@@ -88,6 +91,7 @@ object PresentationRecord {
         anoncredCredentialsToUse,
         sdJwtClaimsToUseJsonSchemaId,
         sdJwtClaimsToDisclose,
+        sdJwtDisclosedClaims,
         metaRetries,
         metaNextRetry,
         metaLastFailure,

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/repository/PresentationRepository.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/repository/PresentationRepository.scala
@@ -47,6 +47,11 @@ trait PresentationRepository {
       protocolState: ProtocolState
   ): URIO[WalletAccessContext, Unit]
 
+  def updateWithSDJWTDisclosedClaims(
+      recordId: DidCommID,
+      sdJwtDisclosedClaims: SdJwtDisclosedClaims,
+  ): URIO[WalletAccessContext, Unit]
+
   def updateWithPresentation(
       recordId: DidCommID,
       presentation: Presentation,

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationService.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationService.scala
@@ -173,7 +173,7 @@ trait PresentationService {
 
   def updateWithSDJWTDisclosedClaims(
       recordId: DidCommID,
-      claimsDisclosed: ast.Json.Obj
+      claimsDisclosed: SdJwtDisclosedClaims
   ): ZIO[WalletAccessContext, PresentationError, PresentationRecord]
 
   def verifyAnoncredPresentation(

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationService.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationService.scala
@@ -171,6 +171,11 @@ trait PresentationService {
       recordId: DidCommID
   ): ZIO[WalletAccessContext, PresentationError, PresentationRecord]
 
+  def updateWithSDJWTDisclosedClaims(
+      recordId: DidCommID,
+      claimsDisclosed: ast.Json.Obj
+  ): ZIO[WalletAccessContext, PresentationError, PresentationRecord]
+
   def verifyAnoncredPresentation(
       presentation: Presentation,
       requestPresentation: RequestPresentation,

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceImpl.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceImpl.scala
@@ -453,6 +453,7 @@ private class PresentationServiceImpl(
         anoncredCredentialsToUse = None,
         sdJwtClaimsToUseJsonSchemaId = None,
         sdJwtClaimsToDisclose = None,
+        sdJwtDisclosedClaims = None,
         metaRetries = maxRetries,
         metaNextRetry = Some(Instant.now()),
         metaLastFailure = None
@@ -532,6 +533,7 @@ private class PresentationServiceImpl(
         anoncredCredentialsToUse = None,
         sdJwtClaimsToUseJsonSchemaId = None,
         sdJwtClaimsToDisclose = None,
+        sdJwtDisclosedClaims = None,
         metaRetries = maxRetries,
         metaNextRetry = Some(Instant.now()),
         metaLastFailure = None,
@@ -861,6 +863,22 @@ private class PresentationServiceImpl(
       _ <- messageProducer
         .produce(TOPIC_NAME, record.id.uuid, WalletIdAndRecordId(walletAccessContext.walletId.toUUID, record.id.uuid))
         .orDie
+      record <- getRecord(recordId)
+    } yield record
+  }
+
+  def updateWithSDJWTDisclosedClaims(
+      recordId: DidCommID,
+      claimsDisclosed: ast.Json.Obj
+  ): ZIO[WalletAccessContext, PresentationError, PresentationRecord] = {
+    for {
+      record <- getRecordWithState(recordId, ProtocolState.PresentationReceived)
+      _ <-
+        presentationRepository
+          .updateWithSDJWTDisclosedClaims(
+            recordId,
+            claimsDisclosed
+          )
       record <- getRecord(recordId)
     } yield record
   }

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceImpl.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceImpl.scala
@@ -869,7 +869,7 @@ private class PresentationServiceImpl(
 
   def updateWithSDJWTDisclosedClaims(
       recordId: DidCommID,
-      claimsDisclosed: ast.Json.Obj
+      claimsDisclosed: SdJwtDisclosedClaims
   ): ZIO[WalletAccessContext, PresentationError, PresentationRecord] = {
     for {
       record <- getRecordWithState(recordId, ProtocolState.PresentationReceived)

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceNotifier.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceNotifier.scala
@@ -332,7 +332,7 @@ class PresentationServiceNotifier(
 
   override def updateWithSDJWTDisclosedClaims(
       recordId: DidCommID,
-      claimsDisclosed: Json.Obj
+      claimsDisclosed: Json
   ): ZIO[WalletAccessContext, PresentationError, PresentationRecord] =
     svc.updateWithSDJWTDisclosedClaims(recordId, claimsDisclosed)
 }

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceNotifier.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceNotifier.scala
@@ -14,6 +14,7 @@ import org.hyperledger.identus.pollux.vc.jwt.{Issuer, PresentationPayload, W3cCr
 import org.hyperledger.identus.shared.models.*
 import zio.*
 import zio.json.*
+import zio.json.ast.Json
 import zio.URIO
 
 import java.time.Instant
@@ -328,6 +329,12 @@ class PresentationServiceNotifier(
       invitation: String
   ): ZIO[WalletAccessContext, PresentationError, RequestPresentation] =
     svc.getRequestPresentationFromInvitation(pairwiseProverDID, invitation)
+
+  override def updateWithSDJWTDisclosedClaims(
+      recordId: DidCommID,
+      claimsDisclosed: Json.Obj
+  ): ZIO[WalletAccessContext, PresentationError, PresentationRecord] =
+    svc.updateWithSDJWTDisclosedClaims(recordId, claimsDisclosed)
 }
 
 object PresentationServiceNotifier {

--- a/pollux/core/src/test/scala/org/hyperledger/identus/pollux/core/repository/PresentationRepositorySpecSuite.scala
+++ b/pollux/core/src/test/scala/org/hyperledger/identus/pollux/core/repository/PresentationRepositorySpecSuite.scala
@@ -36,6 +36,7 @@ object PresentationRepositorySpecSuite {
       anoncredCredentialsToUse = None,
       sdJwtClaimsToUseJsonSchemaId = None,
       sdJwtClaimsToDisclose = None,
+      sdJwtDisclosedClaims = None,
       metaRetries = maxRetries,
       metaNextRetry = Some(Instant.now()),
       metaLastFailure = None

--- a/pollux/core/src/test/scala/org/hyperledger/identus/pollux/core/service/MockPresentationService.scala
+++ b/pollux/core/src/test/scala/org/hyperledger/identus/pollux/core/service/MockPresentationService.scala
@@ -336,7 +336,7 @@ object MockPresentationService extends Mock[PresentationService] {
           recordId: DidCommID,
           claimsDisclosed: ast.Json.Obj
       ): ZIO[WalletAccessContext, PresentationError, PresentationRecord] = ???
-      
+
       override def findPresentationRecordByThreadId(
           thid: DidCommID
       ): IO[PresentationError, Option[PresentationRecord]] =

--- a/pollux/core/src/test/scala/org/hyperledger/identus/pollux/core/service/MockPresentationService.scala
+++ b/pollux/core/src/test/scala/org/hyperledger/identus/pollux/core/service/MockPresentationService.scala
@@ -334,7 +334,7 @@ object MockPresentationService extends Mock[PresentationService] {
 
       def updateWithSDJWTDisclosedClaims(
           recordId: DidCommID,
-          claimsDisclosed: ast.Json.Obj
+          claimsDisclosed: ast.Json
       ): ZIO[WalletAccessContext, PresentationError, PresentationRecord] = ???
 
       override def findPresentationRecordByThreadId(

--- a/pollux/core/src/test/scala/org/hyperledger/identus/pollux/core/service/MockPresentationService.scala
+++ b/pollux/core/src/test/scala/org/hyperledger/identus/pollux/core/service/MockPresentationService.scala
@@ -332,6 +332,11 @@ object MockPresentationService extends Mock[PresentationService] {
       override def findPresentationRecord(recordId: DidCommID): URIO[WalletAccessContext, Option[PresentationRecord]] =
         ???
 
+      def updateWithSDJWTDisclosedClaims(
+          recordId: DidCommID,
+          claimsDisclosed: ast.Json.Obj
+      ): ZIO[WalletAccessContext, PresentationError, PresentationRecord] = ???
+      
       override def findPresentationRecordByThreadId(
           thid: DidCommID
       ): IO[PresentationError, Option[PresentationRecord]] =

--- a/pollux/core/src/test/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceNotifierSpec.scala
+++ b/pollux/core/src/test/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceNotifierSpec.scala
@@ -39,6 +39,7 @@ object PresentationServiceNotifierSpec extends ZIOSpecDefault with PresentationS
     None,
     None,
     None,
+    None,
     5,
     None,
     None,

--- a/pollux/sd-jwt/src/test/scala/org/hyperledger/identus/pollux/sdjwt/ValidClaimsSpec.scala
+++ b/pollux/sd-jwt/src/test/scala/org/hyperledger/identus/pollux/sdjwt/ValidClaimsSpec.scala
@@ -71,7 +71,7 @@ object ValidClaimsSpec extends ZIOSpecDefault {
         """.stripMargin.fromJson[ast.Json.Obj]
       } yield SDJWT.ValidClaims(claims).verifyDiscoseClaims(expected)
       assert(ret)(isRight(equalTo(SDJWT.ClaimsDoNotMatch)))
-    },
+    }
   )
 
 }

--- a/pollux/sql-doobie/src/main/resources/sql/pollux/V30__add_sdjwt_disclosed_claims_columns.sql
+++ b/pollux/sql-doobie/src/main/resources/sql/pollux/V30__add_sdjwt_disclosed_claims_columns.sql
@@ -1,0 +1,3 @@
+-- presentation_records
+ALTER TABLE public.presentation_records
+    ADD COLUMN "sd_jwt_disclosed_claims" JSON;

--- a/pollux/sql-doobie/src/main/scala/org/hyperledger/identus/pollux/sql/repository/JdbcPresentationRepository.scala
+++ b/pollux/sql-doobie/src/main/scala/org/hyperledger/identus/pollux/sql/repository/JdbcPresentationRepository.scala
@@ -166,6 +166,7 @@ class JdbcPresentationRepository(
         |   anoncred_credentials_to_use,
         |   sd_jwt_claims_to_use_json_schema_id,
         |   sd_jwt_claims_to_disclose,
+        |   sd_jwt_disclosed_claims,
         |   meta_retries,
         |   meta_next_retry,
         |   meta_last_failure,
@@ -187,6 +188,7 @@ class JdbcPresentationRepository(
         |   ${record.anoncredCredentialsToUse},
         |   ${record.sdJwtClaimsToUseJsonSchemaId},
         |   ${record.sdJwtClaimsToDisclose},
+        |   ${record.sdJwtDisclosedClaims},
         |   ${record.metaRetries},
         |   ${record.metaNextRetry},
         |   ${record.metaLastFailure},
@@ -226,6 +228,7 @@ class JdbcPresentationRepository(
         |   anoncred_credentials_to_use,
         |   sd_jwt_claims_to_use_json_schema_id,
         |   sd_jwt_claims_to_disclose,
+        |   sd_jwt_disclosed_claims,
         |   meta_retries,
         |   meta_next_retry,
         |   meta_last_failure,
@@ -278,6 +281,7 @@ class JdbcPresentationRepository(
             |   anoncred_credentials_to_use,
             |   sd_jwt_claims_to_use_json_schema_id,
             |   sd_jwt_claims_to_disclose,
+            |   sd_jwt_disclosed_claims,
             |   meta_retries,
             |   meta_next_retry,
             |   meta_last_failure,
@@ -327,6 +331,7 @@ class JdbcPresentationRepository(
         |   anoncred_credentials_to_use,
         |   sd_jwt_claims_to_use_json_schema_id,
         |   sd_jwt_claims_to_disclose,
+        |   sd_jwt_disclosed_claims,
         |   meta_retries,
         |   meta_next_retry,
         |   meta_last_failure,
@@ -365,6 +370,7 @@ class JdbcPresentationRepository(
         |   anoncred_credentials_to_use,
         |   sd_jwt_claims_to_use_json_schema_id,
         |   sd_jwt_claims_to_disclose,
+        |   sd_jwt_disclosed_claims,
         |   meta_retries,
         |   meta_next_retry,
         |   meta_last_failure,
@@ -401,6 +407,7 @@ class JdbcPresentationRepository(
         |   anoncred_credentials_to_use,
         |   sd_jwt_claims_to_use_json_schema_id,
         |   sd_jwt_claims_to_disclose,
+        |   sd_jwt_disclosed_claims,
         |   meta_retries,
         |   meta_next_retry,
         |   meta_last_failure,
@@ -503,6 +510,28 @@ class JdbcPresentationRepository(
         |   meta_last_failure = null
         | WHERE
         |   id = $recordId
+        """.stripMargin.update
+
+    cxnIO.run
+      .transactWallet(xa)
+      .orDie
+      .ensureOneAffectedRowOrDie
+  }
+
+  override def updateWithSDJWTDisclosedClaims(
+      recordId: DidCommID,
+      sdJwtDisclosedClaims: SdJwtDisclosedClaims
+  ): URIO[WalletAccessContext, Unit] = {
+    val cxnIO = sql"""
+                     | UPDATE public.presentation_records
+                     | SET
+                     |   sd_jwt_disclosed_claims = $sdJwtDisclosedClaims,
+                     |   updated_at = ${Instant.now},
+                     |   meta_retries = $maxRetries,
+                     |   meta_next_retry = ${Instant.now},
+                     |   meta_last_failure = null
+                     | WHERE
+                     |   id = $recordId
         """.stripMargin.update
 
     cxnIO.run


### PR DESCRIPTION
### Description: 
https://github.com/hyperledger/identus-cloud-agent/issues/1430

currently api does not display disclosed claim information.  this endpoint to reveal disclosed claims for greater clarity
{{baseUrlVerifier}}/present-proof/presentations/{{VERIFIER_PRESENTATION_ID}}
This PR fixed the this issue

### Alternatives Considered (optional): 
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
