### PR TITLE
fix: documentation build

### DIFF
--- a/docs/docusaurus/credentials/oid4vci/issue.md
+++ b/docs/docusaurus/credentials/oid4vci/issue.md
@@ -1,4 +1,4 @@
-# Issue credentials (OID4VC)
+# Issue credentials (OID4VCI)
 
 [OID4VCI](/docs/concepts/glossary#oid4vci) (OpenID for Verifiable Credential Issuance) is a protocol that extends OAuth2 to issue credentials.
 It involves a Credential Issuer server and an Authorization server working together,

--- a/docs/docusaurus/sidebars.js
+++ b/docs/docusaurus/sidebars.js
@@ -21,7 +21,7 @@ const sidebars = {
       items: [
         'credentials/didcomm/issue',
         'credentials/connectionless/issue',
-        'credentials/oid4ci/issue',
+        'credentials/oid4vci/issue',
         'credentials/didcomm/present-proof',
         'credentials/revocation'
       ]


### PR DESCRIPTION
### Description: 
There were a couple of typos in the docusaurus directory that failed the build of the documentation portal.
This PR fixed the issue.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
