### PR TITLE
fix: broken links in the docusaurus documentation files

### DIFF
--- a/docs/docusaurus/credentials/oid4vci/issue.md
+++ b/docs/docusaurus/credentials/oid4vci/issue.md
@@ -1,4 +1,4 @@
-# Issue credentials (OID4VC)
+# Issue credentials (OID4VCI)
 
 [OID4VCI](/docs/concepts/glossary#oid4vci) (OpenID for Verifiable Credential Issuance) is a protocol that extends OAuth2 to issue credentials.
 It involves a Credential Issuer server and an Authorization server working together,

--- a/docs/docusaurus/credentials/revocation.md
+++ b/docs/docusaurus/credentials/revocation.md
@@ -169,5 +169,5 @@ curl -X 'PATCH' \
 ```
 
 :::note
-[Present proof](./issue.md) will fail the verification if one of the credentials the holder presents a revoked credential.
+[Present proof](./didcomm/issue.md) will fail the verification if one of the credentials the holder presents a revoked credential.
 :::

--- a/docs/docusaurus/sidebars.js
+++ b/docs/docusaurus/sidebars.js
@@ -21,7 +21,7 @@ const sidebars = {
       items: [
         'credentials/didcomm/issue',
         'credentials/connectionless/issue',
-        'credentials/oid4ci/issue',
+        'credentials/oid4vci/issue',
         'credentials/didcomm/present-proof',
         'credentials/revocation'
       ]

--- a/docs/docusaurus/webhooks/webhook.md
+++ b/docs/docusaurus/webhooks/webhook.md
@@ -156,8 +156,8 @@ generated):
 ### Common Event Types
 
 The Cloud Agent sends webhook notifications for events related to protocol state changes in
-the [Connect](/tutorials/connections/connection), [Issue](/tutorials/credentials/issue),
-[Presentation](/tutorials/credentials/present-proof) flows, and also [DID publication](/tutorials/dids/publish)
+the [Connect](/tutorials/connections/connection), [Issue](/tutorials/credentials/didcomm/issue),
+[Presentation](/tutorials/credentials/didcomm/present-proof) flows, and also [DID publication](/tutorials/dids/publish)
 state changes. These events allow you to track the progress and updates within these flows in real-time.
 
 The `id` field of the common event structure is the unique identifier (UUID) of the event and is randomly generated at

--- a/docs/docusaurus/webhooks/webhook.md
+++ b/docs/docusaurus/webhooks/webhook.md
@@ -20,8 +20,8 @@ systems.
 Webhook notifications in the CLoud Agent serve as a vital feature, enabling you to receive timely updates on various events
 occurring within the agent. Webhooks allow you to receive HTTP requests containing event details at a specified
 endpoint (webhook URL). These events are specifically related to the execution of
-the [Connect](/tutorials/connections/connection), [Issue](/tutorials/credentials/issue),
-and [Presentation](/tutorials/credentials/present-proof) flows. Webhook notifications will be sent each time there is a
+the [Connect](/tutorials/connections/connection), [Issue](/tutorials/credentials/didcomm/issue),
+and [Presentation](/tutorials/credentials/didcomm/present-proof) flows. Webhook notifications will be sent each time there is a
 state
 change during the execution of these protocols.
 


### PR DESCRIPTION
### Description: 
A couple of broken links in the previous commit were not correctly detected.
This PR contains these tiny fixes.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
