### PR TITLE
chore: update actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Publish Cloud-Agent Open API Specification
         id: upload-oas
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cloud-agent-openapi-spec-${{ env.OAS_CHECKSUM}}
           path: ./cloud-agent-openapi-spec-${{ env.REVISION_VERSION}}.yaml

--- a/.github/workflows/release-clients.yml
+++ b/.github/workflows/release-clients.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Download OpenAPI specification
         if: ${{ !inputs.releaseTag }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: cloud-agent-openapi-spec-${{ inputs.check_sum }}
           path: ./cloud-agent/service/api/http


### PR DESCRIPTION
### Description: 

actions/upload-artifact and actions/download-artifact have been deprecated and need updated.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/


### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
