### PR TITLE
fix: openAPI mutability #1115

### DIFF
--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/api/http/ErrorResponse.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/api/http/ErrorResponse.scala
@@ -34,6 +34,14 @@ case class ErrorResponse(
 )
 
 object ErrorResponse {
+  val example = ErrorResponse(
+    404,
+    "NotFound",
+    "Not Found",
+    Some("The requested resource was not found"),
+    INSTANCE_URI_PREFIX + UUID.fromString("f47ac10b-58cc-4372-a567-0e02b2c3d479")
+  )
+
   given encoder: zio.json.JsonEncoder[ErrorResponse] = DeriveJsonEncoder.gen[ErrorResponse]
 
   given decoder: zio.json.JsonDecoder[ErrorResponse] = DeriveJsonDecoder.gen[ErrorResponse]

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/connect/controller/http/Connection.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/connect/controller/http/Connection.scala
@@ -5,7 +5,6 @@ import org.hyperledger.identus.connect.controller.http.Connection.annotations
 import org.hyperledger.identus.connect.controller.http.Connection.annotations.goalcode
 import org.hyperledger.identus.connect.core.model
 import org.hyperledger.identus.connect.core.model.ConnectionRecord.Role
-import org.hyperledger.identus.shared.models.{FailureInfo, StatusCode}
 import sttp.model.Uri
 import sttp.tapir.{Schema, Validator}
 import sttp.tapir.Schema.annotations.{description, encodedExample, validate}
@@ -207,8 +206,7 @@ object Connection {
     object metaLastFailure
         extends Annotation[ErrorResponse](
           description = "The last failure if any.",
-          example =
-            ErrorResponse.failureToErrorResponseConversion(FailureInfo("Error", StatusCode.NotFound, "Not Found"))
+          example = ErrorResponse.example
         )
 
     object self

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/credentialstatus/controller/http/StatusListCredential.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/credentialstatus/controller/http/StatusListCredential.scala
@@ -84,7 +84,7 @@ object StatusListCredential {
     object issuanceDate
         extends Annotation[Instant](
           description = "Issuance timestamp of status list credential",
-          example = Instant.now()
+          example = Instant.parse("2025-01-01T22:40:34.560891Z")
         )
 
     object credentialSubject {

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/issue/controller/http/IssueCredentialRecord.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/issue/controller/http/IssueCredentialRecord.scala
@@ -4,7 +4,6 @@ import org.hyperledger.identus.api.http.{Annotation, ErrorResponse}
 import org.hyperledger.identus.issue.controller.http.IssueCredentialRecord.annotations
 import org.hyperledger.identus.mercury.model.{AttachmentDescriptor, Base64}
 import org.hyperledger.identus.pollux.core.model.IssueCredentialRecord as PolluxIssueCredentialRecord
-import org.hyperledger.identus.shared.models.{FailureInfo, StatusCode}
 import sttp.tapir.{Schema, Validator}
 import sttp.tapir.json.zio.schemaForZioJsonValue
 import sttp.tapir.Schema.annotations.{description, encodedExample, validate}
@@ -195,7 +194,7 @@ object IssueCredentialRecord {
     object createdAt
         extends Annotation[OffsetDateTime](
           description = "The date and time when the issue credential record was created.",
-          example = OffsetDateTime.now()
+          example = OffsetDateTime.parse("2023-01-01T00:00:00Z")
         )
 
     object updatedAt
@@ -295,8 +294,7 @@ object IssueCredentialRecord {
     object metaLastFailure
         extends Annotation[ErrorResponse](
           description = "The last failure if any.",
-          example =
-            ErrorResponse.failureToErrorResponseConversion(FailureInfo("Error", StatusCode.NotFound, "Not Found"))
+          example = ErrorResponse.example
         )
 
   }

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/presentproof/controller/http/PresentationStatus.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/presentproof/controller/http/PresentationStatus.scala
@@ -5,7 +5,6 @@ import org.hyperledger.identus.mercury.model.{AttachmentDescriptor, Base64, Json
 import org.hyperledger.identus.mercury.protocol.presentproof.{Presentation, RequestPresentation}
 import org.hyperledger.identus.pollux.core.model.PresentationRecord
 import org.hyperledger.identus.presentproof.controller.http.PresentationStatus.annotations
-import org.hyperledger.identus.shared.models.{FailureInfo, StatusCode}
 import sttp.tapir.{Schema, Validator}
 import sttp.tapir.json.zio.schemaForZioJsonValue
 import sttp.tapir.Schema.annotations.{description, encodedExample, validate}
@@ -196,8 +195,7 @@ object PresentationStatus {
     object metaLastFailure
         extends Annotation[ErrorResponse](
           description = "The last failure if any.",
-          example =
-            ErrorResponse.failureToErrorResponseConversion(FailureInfo("Error", StatusCode.NotFound, "Not Found"))
+          example = ErrorResponse.example
         )
 
     object goalcode


### PR DESCRIPTION
### Description: 
This PR fixes issue #1115: OAS is mutated from build to build because of Instant.now() and UUID.random() functions were used in the annotations.

I tried to implement the integration tests, but it's not trivial and fragile because the Tapir OAS is static and a lot of classes must be reloaded or isolated in the dedicated classloader.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
